### PR TITLE
feat: performance optimizations, i18n support, and component refactor

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+## 🔗 Related Issue
+Closes #issue-number
+
+---
+
+## 🔖 Title
+<!-- Brief and clear. Describe the specific task -->
+
+---
+
+## 📝 Description
+<!-- Describe the changes made in this PR. What problem does it solve? -->
+
+---
+
+## 🔄 Changes Made
+<!-- List the main changes in this PR -->
+- [ ] <!-- Change 1 -->
+- [ ] <!-- Change 2 -->
+- [ ] <!-- Change 3 -->
+
+---
+
+## 📸 Screenshots (if applicable)
+<!-- Add screenshots or GIFs if the changes affect the UI -->
+
+---
+
+## 🗒️ Additional Notes
+<!-- Any additional information, concerns, or context for reviewers -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx tsc --noEmit
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -353,8 +353,8 @@ body {
 .phone-card-label { font-size: 0.6rem; font-weight: 700; opacity: 0.9; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 4px; }
 .phone-card-title { font-size: 0.9rem; font-weight: 600; margin-bottom: 8px; }
 .phone-progress-bar { background: rgba(255,255,255,0.3); border-radius: 100px; height: 4px; overflow: hidden; }
-.phone-progress-fill { background: white; height: 100%; width: 65%; border-radius: 100px; animation: progressLoad 2s ease 1s both; }
-@keyframes progressLoad { from { width: 0; } to { width: 65%; } }
+.phone-progress-fill { background: white; height: 100%; width: 100%; border-radius: 100px; transform: scaleX(0.65); transform-origin: left; animation: progressLoad 2s ease 1s both; }
+@keyframes progressLoad { from { transform: scaleX(0); } to { transform: scaleX(0.65); } }
 
 .phone-tasks { display: flex; flex-direction: column; gap: 8px; }
 .phone-task { display: flex; align-items: center; gap: 10px; padding: 10px 12px; background: #f3f6fa; border-radius: 12px; border: 1px solid rgba(91,143,185,0.08); }
@@ -367,8 +367,7 @@ body {
 
 .hero-chip {
   position: absolute;
-  background: rgba(255,255,255,0.9);
-  backdrop-filter: blur(8px);
+  background: rgba(255,255,255,0.96);
   border-radius: 100px;
   padding: 0.6rem 1rem;
   box-shadow: 0 12px 32px rgba(26,23,20,0.08), 0 0 0 1px rgba(91,143,185,0.1);
@@ -406,9 +405,7 @@ section { padding: 6rem 2rem; }
 /* ── MANIFESTO (Translucent Dark Glassmorphism) ── */
 /* Added a more explicit border and strong box shadow so it separates gracefully from the background */
 .manifesto {
-  background: rgba(15, 23, 42, 0.9); /* Opaque enough to hide background without massive blur */
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+  background: rgba(15, 23, 42, 0.94);
   color: #ffffff;
   text-align: center;
   padding: 7rem 2rem;
@@ -439,36 +436,96 @@ section { padding: 6rem 2rem; }
 .features-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1.5rem; margin-top: 4rem; }
 
 .feature-card {
-  background: rgba(255, 255, 255, 0.7);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  border-radius: 24px;
-  padding: 2rem;
-  border: 1px solid rgba(255, 255, 255, 0.9);
-  transition: transform 0.2s, box-shadow 0.2s, background 0.2s;
+  background: #ffffff;
+  border-radius: 40px; /* Even smoother radius */
+  padding: 3rem 2.5rem;
+  border: 1px solid rgba(0, 0, 0, 0.04);
+  transition: all 0.6s cubic-bezier(0.23, 1, 0.32, 1);
   position: relative;
   overflow: hidden;
-  box-shadow: 0 16px 40px rgba(91,143,185,0.08), inset 0 0 0 1px rgba(255,255,255,0.4);
+  box-shadow: 
+    0 10px 40px -10px rgba(0, 0, 0, 0.02),
+    0 2px 4px rgba(0, 0, 0, 0.01);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
 }
 
-.feature-card::before { content: ''; position: absolute; top: 0; left: 0; right: 0; height: 4px; border-radius: 24px 24px 0 0; }
-.feature-card.rose::before { background: linear-gradient(90deg, var(--primary), var(--primary-soft)); }
-.feature-card.sage::before { background: linear-gradient(90deg, var(--secondary), #9ECB9E); }
-.feature-card.lavender::before { background: linear-gradient(90deg, var(--accent), var(--deep-lavender)); }
+.feature-card:hover {
+  transform: translateY(-12px) scale(1.02);
+  box-shadow: 
+    0 40px 80px -15px rgba(0, 0, 0, 0.08),
+    0 0 0 1px rgba(0, 0, 0, 0.02);
+}
 
-.feature-card:hover { transform: translateY(-4px); box-shadow: 0 24px 48px rgba(91,143,185,0.15); background: rgba(255, 255, 255, 0.75); }
+.feature-card.rose:hover { box-shadow: 0 20px 48px rgba(91,143,185,0.15); }
+.feature-card.sage:hover { box-shadow: 0 20px 48px rgba(123,174,127,0.15); }
+.feature-card.lavender:hover { box-shadow: 0 20px 48px rgba(184,169,201,0.15); }
 
-.feature-icon { width: 48px; height: 48px; border-radius: 14px; display: flex; align-items: center; justify-content: center; font-size: 1.4rem; margin-bottom: 1.25rem; font-weight: 700; color: var(--ink); box-shadow: 0 4px 12px rgba(0,0,0,0.05); border: 1px solid rgba(255,255,255,0.6); }
-.feature-icon.rose { background: rgba(91,143,185,0.25); }
-.feature-icon.sage { background: rgba(123,174,127,0.25); }
-.feature-icon.lavender { background: rgba(184,169,201,0.25); }
+.feature-icon { 
+  width: 64px; 
+  height: 64px; 
+  border-radius: 22px; 
+  display: flex; 
+  align-items: center; 
+  justify-content: center; 
+  font-size: 1.8rem; 
+  margin-bottom: 2.5rem; 
+  background: var(--bg);
+  border: 1px solid rgba(0, 0, 0, 0.03);
+  transition: all 0.4s ease;
+  position: relative;
+  z-index: 1;
+}
 
-.feature-title { font-family: 'Playfair Display', serif; font-size: 1.2rem; font-weight: 700; color: var(--ink); margin-bottom: 0.5rem; }
-.feature-body { font-size: 0.9rem; font-weight: 500; color: var(--ink-soft); line-height: 1.65; }
+.feature-card.rose .feature-icon { background: #EEF6FF; color: var(--primary); }
+.feature-card.sage .feature-icon { background: #F0F9F1; color: var(--secondary); }
+.feature-card.lavender .feature-icon { background: #F6F4F9; color: var(--accent); }
+
+.feature-card:hover .feature-icon {
+  transform: rotate(10deg) scale(1.1);
+  box-shadow: 0 15px 30px -5px rgba(0, 0, 0, 0.05);
+}
+
+.feature-title { 
+  font-family: 'DM Sans', sans-serif;
+  font-size: 1.4rem; 
+  font-weight: 800; 
+  color: var(--ink); 
+  margin-bottom: 1rem; 
+  letter-spacing: -0.03em;
+  position: relative;
+  z-index: 1;
+}
+
+.feature-body { 
+  font-size: 1.05rem; 
+  font-weight: 400; 
+  color: var(--ink-soft); 
+  line-height: 1.6; 
+  opacity: 0.8;
+  position: relative;
+  z-index: 1;
+}
+
+/* Corner indicator refined */
+.card-indicator {
+  position: absolute;
+  top: 1.5rem;
+  right: 1.5rem;
+  font-size: 0.65rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  opacity: 0.2;
+  transition: opacity 0.4s ease;
+}
+.feature-card:hover .card-indicator { opacity: 0.5; }
 
 /* ── VS TIIMO COMPARE ── */
 .compare-header { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 1px; background: rgba(255, 255, 255, 0.8); border-radius: 20px 20px 0 0; overflow: hidden; margin-top: 3rem; border: 1px solid rgba(255, 255, 255, 0.9); border-bottom: none; box-shadow: 0 16px 40px rgba(91,143,185,0.05); }
-.compare-col-head { background: rgba(255,255,255,0.6); backdrop-filter: blur(12px); padding: 1.5rem; text-align: center; }
+.compare-col-head { background: rgba(255,255,255,0.85); backdrop-filter: blur(4px); -webkit-backdrop-filter: blur(4px); padding: 1.5rem; text-align: center; }
 .compare-col-head.flowe { background: var(--ink); color: #ffffff; }
 .compare-brand { font-family: 'Playfair Display', serif; font-size: 1.1rem; font-weight: 700; }
 .compare-brand.flowe-brand { color: var(--warning); /* pop against ink */ }
@@ -477,7 +534,7 @@ section { padding: 6rem 2rem; }
 .compare-body { border-radius: 0 0 20px 20px; overflow: hidden; border: 1px solid rgba(255, 255, 255, 0.9); border-top: none; box-shadow: 0 16px 40px rgba(91,143,185,0.05); }
 .compare-row { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 1px; background: rgba(255, 255, 255, 0.4); }
 .compare-row:last-child .compare-cell { border-bottom: none; }
-.compare-cell { background: rgba(255,255,255,0.6); backdrop-filter: blur(12px); padding: 1rem 1.5rem; font-size: 0.875rem; font-weight: 500; color: var(--ink-soft); display: flex; align-items: center; gap: 0.5rem; }
+.compare-cell { background: rgba(255,255,255,0.85); padding: 1rem 1.5rem; font-size: 0.875rem; font-weight: 500; color: var(--ink-soft); display: flex; align-items: center; gap: 0.5rem; }
 .compare-cell.feature-name { font-weight: 600; color: var(--ink); }
 .compare-cell.flowe-cell { background: rgba(91,143,185,0.12); font-weight: 600; color: var(--ink); }
 .check { color: var(--deep-sage); font-size: 1.1rem; font-weight: 700; }
@@ -485,7 +542,7 @@ section { padding: 6rem 2rem; }
 
 /* ── TESTIMONIALS ── */
 .testimonials-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.5rem; margin-top: 3rem; }
-.testimonial-card { background: rgba(255, 255, 255, 0.7); backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px); border-radius: 24px; padding: 1.75rem; border: 1px solid rgba(255, 255, 255, 0.9); position: relative; transition: transform 0.2s, box-shadow 0.2s; box-shadow: 0 16px 40px rgba(91,143,185,0.08); }
+.testimonial-card { background: rgba(255, 255, 255, 0.78); backdrop-filter: blur(4px); -webkit-backdrop-filter: blur(4px); border-radius: 24px; padding: 1.75rem; border: 1px solid rgba(255, 255, 255, 0.9); position: relative; transition: transform 0.2s, box-shadow 0.2s; box-shadow: 0 16px 40px rgba(91,143,185,0.08); }
 .testimonial-card:hover { transform: translateY(-4px); box-shadow: 0 24px 48px rgba(91,143,185,0.15); background: rgba(255, 255, 255, 0.85); }
 .testimonial-quote-mark { font-family: 'Playfair Display', serif; font-size: 3.5rem; color: var(--primary); line-height: 1; margin-bottom: 0.5rem; opacity: 0.6; }
 .testimonial-text { font-size: 0.95rem; font-weight: 500; color: var(--ink-soft); line-height: 1.7; font-style: italic; margin-bottom: 1.25rem; }
@@ -498,7 +555,7 @@ section { padding: 6rem 2rem; }
 .author-label { font-size: 0.75rem; font-weight: 500; color: var(--ink-light); }
 
 /* ── BETA CTA ── */
-.beta-cta { background: rgba(15, 23, 42, 0.9); backdrop-filter: blur(8px); position: relative; overflow: hidden; padding: 8rem 2rem; border-top: 1px solid rgba(255,255,255,0.1); border-bottom: 1px solid rgba(255,255,255,0.1); box-shadow: 0 -24px 64px rgba(15, 23, 42, 0.15); }
+.beta-cta { background: rgba(15, 23, 42, 0.96); position: relative; overflow: hidden; padding: 8rem 2rem; border-top: 1px solid rgba(255,255,255,0.1); border-bottom: 1px solid rgba(255,255,255,0.1); box-shadow: 0 -24px 64px rgba(15, 23, 42, 0.15); }
 .beta-cta::before { content: ''; position: absolute; inset: 0; background: radial-gradient(ellipse at 30% 60%, rgba(91,143,185,0.2) 0%, transparent 55%), radial-gradient(ellipse at 75% 30%, rgba(123,174,127,0.15) 0%, transparent 55%); pointer-events: none; }
 .beta-inner { max-width: 640px; margin: 0 auto; text-align: center; position: relative; z-index: 2; }
 .beta-title { font-family: 'Playfair Display', serif; font-size: clamp(2.2rem, 5vw, 3.5rem); font-weight: 700; color: #ffffff; line-height: 1.15; letter-spacing: -0.02em; margin-bottom: 1.25rem; text-shadow: 0 4px 16px rgba(0,0,0,0.4); }
@@ -517,7 +574,7 @@ section { padding: 6rem 2rem; }
 
 /* ── UPDATES / BLOG ── */
 .updates-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.5rem; margin-top: 3rem; }
-.update-card { border-radius: 20px; overflow: hidden; border: 1px solid rgba(255, 255, 255, 0.9); background: rgba(255, 255, 255, 0.7); backdrop-filter: blur(8px); transition: transform 0.2s, box-shadow 0.2s; cursor: pointer; text-decoration: none; display: block; color: inherit; box-shadow: 0 16px 40px rgba(91,143,185,0.08); }
+.update-card { border-radius: 20px; overflow: hidden; border: 1px solid rgba(255, 255, 255, 0.9); background: rgba(255, 255, 255, 0.78); backdrop-filter: blur(4px); -webkit-backdrop-filter: blur(4px); transition: transform 0.2s, box-shadow 0.2s; cursor: pointer; text-decoration: none; display: block; color: inherit; box-shadow: 0 16px 40px rgba(91,143,185,0.08); }
 .update-card:hover { transform: translateY(-4px); box-shadow: 0 24px 48px rgba(91,143,185,0.15); background: rgba(255, 255, 255, 0.85); }
 .update-banner { height: 140px; display: flex; align-items: center; justify-content: center; font-size: 2.5rem; position: relative; overflow: hidden; }
 .update-banner.rose-bg { background: linear-gradient(135deg, rgba(221,234,245,0.8), rgba(196,216,236,0.8)); }
@@ -530,25 +587,101 @@ section { padding: 6rem 2rem; }
 .update-date { font-size: 0.8rem; font-weight: 600; color: var(--ink-light); margin-top: 0.75rem; font-family: 'DM Mono', monospace; }
 
 /* ── FOOTER ── */
-footer { background: var(--ink); color: #ffffff; padding: 4rem 2rem 2rem; position: relative; z-index: 10; }
+.footer-section {
+  background: #0A0F1A; /* Deeper than beta for visual grounding */
+  color: #ffffff;
+  padding: 6rem 2rem 4rem;
+  position: relative;
+  z-index: 10;
+}
 .footer-inner { max-width: 1100px; margin: 0 auto; }
-.footer-top { display: grid; grid-template-columns: 1.5fr repeat(3, 1fr); gap: 3rem; padding-bottom: 3rem; border-bottom: 1px solid rgba(255,255,255,0.1); }
-.footer-brand { font-family: 'Playfair Display', serif; font-size: 1.5rem; font-weight: 700; color: #ffffff; margin-bottom: 0.5rem; }
+.footer-top { 
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  gap: 4rem;
+  flex-wrap: wrap;
+}
+.footer-brand-col { max-width: 320px; }
+.footer-brand { 
+  font-family: 'Playfair Display', serif; 
+  font-size: 1.75rem; 
+  font-weight: 700; 
+  color: #ffffff; 
+  margin-bottom: 1.25rem; 
+}
 .footer-brand span { color: var(--primary-soft); }
-.footer-tagline { font-size: 0.9rem; font-weight: 400; opacity: 0.7; margin-bottom: 1.5rem; line-height: 1.5; }
-.footer-social { display: flex; gap: 0.75rem; }
-.social-btn { width: 36px; height: 36px; border-radius: 50%; background: rgba(255,255,255,0.1); display: flex; align-items: center; justify-content: center; font-size: 0.9rem; cursor: pointer; transition: background 0.2s; text-decoration: none; color: #ffffff; }
-.social-btn:hover { background: rgba(255,255,255,0.2); }
-.footer-col-title { font-size: 0.75rem; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; opacity: 0.5; margin-bottom: 1rem; color: #ffffff; }
-.footer-links { list-style: none; display: flex; flex-direction: column; gap: 0.6rem; }
-.footer-links a { font-size: 0.9rem; font-weight: 400; color: rgba(255,255,255,0.7); text-decoration: none; transition: color 0.2s; }
-.footer-links a:hover { color: #ffffff; }
-.footer-bottom { padding-top: 1.75rem; display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem; }
-.footer-copy { font-size: 0.85rem; opacity: 0.5; font-weight: 400; }
-.footer-made { font-size: 0.85rem; opacity: 0.5; font-weight: 400; }
+.footer-tagline { 
+  font-size: 0.95rem; 
+  font-weight: 400; 
+  opacity: 0.6; 
+  margin-bottom: 2rem; 
+  line-height: 1.6; 
+}
+.footer-social { display: flex; gap: 1rem; }
+.social-link { 
+  width: 42px; 
+  height: 42px; 
+  border-radius: 12px; 
+  background: rgba(255,255,255,0.05); 
+  display: flex; 
+  align-items: center; 
+  justify-content: center; 
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1); 
+  text-decoration: none; 
+  color: rgba(255,255,255,0.6); 
+  border: 1px solid rgba(255,255,255,0.05);
+}
+.social-link:hover { 
+  background: rgba(255,255,255,0.1); 
+  color: #ffffff;
+  transform: translateY(-3px);
+  border-color: rgba(255,255,255,0.2);
+}
+.footer-nav-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 4rem;
+}
+.footer-col-title { 
+  font-size: 0.75rem; 
+  font-weight: 700; 
+  letter-spacing: 0.15em; 
+  text-transform: uppercase; 
+  opacity: 0.4; 
+  margin-bottom: 1.5rem; 
+  color: #ffffff; 
+}
+.footer-links { list-style: none; display: flex; flex-direction: column; gap: 0.8rem; }
+.footer-links a { 
+  font-size: 0.9rem; 
+  font-weight: 500; 
+  color: rgba(255,255,255,0.5); 
+  text-decoration: none; 
+  transition: color 0.2s; 
+}
+.footer-links a:hover { color: var(--primary-soft); }
+
+.footer-bottom { 
+  margin-top: 5rem;
+}
+.footer-bottom-line {
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.1), transparent);
+  margin-bottom: 2rem;
+}
+.footer-bottom-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+.footer-copy { font-size: 0.85rem; opacity: 0.4; font-weight: 400; }
+.footer-made { font-size: 0.85rem; opacity: 0.4; font-weight: 400; }
 
 /* ── SCROLL ANIMATIONS ── */
-.reveal { opacity: 0; transform: translateY(30px); transition: opacity 0.7s cubic-bezier(0.2, 0.8, 0.2, 1), transform 0.7s cubic-bezier(0.2, 0.8, 0.2, 1); will-change: opacity, transform; }
+.reveal { opacity: 0; transform: translateY(16px); transition: opacity 0.4s ease, transform 0.4s ease; }
 .reveal.visible { opacity: 1; transform: translateY(0); }
 
 /* ── RESPONSIVE ── */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,8 @@ export const metadata: Metadata = {
   description: "A routines app designed for the way your brain actually works — with adaptive AI, visual schedules, and zero overwhelm.",
 };
 
+import { LanguageProvider } from "@/context/LanguageContext";
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -27,10 +29,12 @@ export default function RootLayout({
         />
       </head>
       <body>
-        <ShaderBackground />
-        <main className="w-full relative z-10 flex flex-col">
-          {children}
-        </main>
+        <LanguageProvider>
+          <ShaderBackground />
+          <main className="w-full relative z-10 flex flex-col">
+            {children}
+          </main>
+        </LanguageProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,6 +21,13 @@ export default function Home() {
           if (entry.isIntersecting) {
             entry.target.classList.add("visible");
             observer.unobserve(entry.target);
+            // Free compositor layer once animation is done
+            const el = entry.target as HTMLElement;
+            el.addEventListener(
+              "transitionend",
+              () => { el.style.willChange = "auto"; },
+              { once: true }
+            );
           }
         });
       },

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,93 +1,78 @@
 import Image from "next/image";
+import { useLanguage } from "@/context/LanguageContext";
+import { TwitterIcon, InstagramIcon, DiscordIcon, GithubIcon } from "@/components/ui/Icons";
 
 export default function Footer() {
+  const { t } = useLanguage();
+
   return (
-    <footer>
+    <footer className="footer-section">
       <div className="footer-inner">
         <div className="footer-top">
-          <div>
+          <div className="footer-brand-col">
             <div className="footer-brand flex items-center gap-2">
               <Image src="/logo-flowe.png" alt="Flowē Logo" width={32} height={32} className="object-contain" />
               <span>Flowē<span>.</span></span>
             </div>
-            <p className="footer-tagline">
-              Your rhythm, your flow.
-              <br />A productivity app for neurodivergent minds.
-            </p>
+            <p 
+              className="footer-tagline"
+              dangerouslySetInnerHTML={{ __html: t.footer.tagline }}
+            />
             <div className="footer-social">
-              <a href="#" className="social-btn" title="Twitter/X">
-                𝕏
+              <a href="#" className="social-link" title="Twitter/X">
+                <TwitterIcon />
               </a>
-              <a href="#" className="social-btn" title="Instagram">
-                ◻
+              <a href="#" className="social-link" title="Instagram">
+                <InstagramIcon />
               </a>
-              <a href="#" className="social-btn" title="Discord">
-                ◈
+              <a href="#" className="social-link" title="Discord">
+                <DiscordIcon />
               </a>
-              <a href="#" className="social-btn" title="GitHub">
-                ⌥
+              <a href="#" className="social-link" title="GitHub">
+                <GithubIcon />
               </a>
             </div>
           </div>
 
-          <div>
-            <div className="footer-col-title">Product</div>
-            <ul className="footer-links">
-              <li>
-                <a href="#features">Features</a>
-              </li>
-              <li>
-                <a href="#compare">Why Flowē</a>
-              </li>
-              <li>
-                <a href="#beta">Join Beta</a>
-              </li>
-              <li>
-                <a href="#">Roadmap</a>
-              </li>
-            </ul>
-          </div>
+          <div className="footer-nav-grid">
+            <div>
+              <div className="footer-col-title">{t.footer.cols.product.title}</div>
+              <ul className="footer-links">
+                <li><a href="#features">{t.footer.cols.product.links[0]}</a></li>
+                <li><a href="#compare">{t.footer.cols.product.links[1]}</a></li>
+                <li><a href="#beta">{t.footer.cols.product.links[2]}</a></li>
+                <li><a href="#">{t.footer.cols.product.links[3]}</a></li>
+              </ul>
+            </div>
 
-          <div>
-            <div className="footer-col-title">Updates</div>
-            <ul className="footer-links">
-              <li>
-                <a href="#">Blog</a>
-              </li>
-              <li>
-                <a href="#">Changelog</a>
-              </li>
-              <li>
-                <a href="#">Dev Notes</a>
-              </li>
-              <li>
-                <a href="#">Newsletter</a>
-              </li>
-            </ul>
-          </div>
+            <div>
+              <div className="footer-col-title">{t.footer.cols.updates.title}</div>
+              <ul className="footer-links">
+                <li><a href="#">{t.footer.cols.updates.links[0]}</a></li>
+                <li><a href="#">{t.footer.cols.updates.links[1]}</a></li>
+                <li><a href="#">{t.footer.cols.updates.links[2]}</a></li>
+                <li><a href="#">{t.footer.cols.updates.links[3]}</a></li>
+              </ul>
+            </div>
 
-          <div>
-            <div className="footer-col-title">Info</div>
-            <ul className="footer-links">
-              <li>
-                <a href="#">About</a>
-              </li>
-              <li>
-                <a href="#">Privacy Policy</a>
-              </li>
-              <li>
-                <a href="#">Terms</a>
-              </li>
-              <li>
-                <a href="#">Contact</a>
-              </li>
-            </ul>
+            <div>
+              <div className="footer-col-title">{t.footer.cols.info.title}</div>
+              <ul className="footer-links">
+                <li><a href="#">{t.footer.cols.info.links[0]}</a></li>
+                <li><a href="#">{t.footer.cols.info.links[1]}</a></li>
+                <li><a href="#">{t.footer.cols.info.links[2]}</a></li>
+                <li><a href="#">{t.footer.cols.info.links[3]}</a></li>
+              </ul>
+            </div>
           </div>
         </div>
 
         <div className="footer-bottom">
-          <span className="footer-copy">© 2025 Flowē. All rights reserved.</span>
-          <span className="footer-made">Made with care in Costa Rica 🇨🇷</span>
+          <div className="footer-bottom-line"></div>
+          <div className="footer-bottom-content">
+            <span className="footer-copy">{t.footer.copy}</span>
+            <span className="footer-made">{t.footer.made}</span>
+          </div>
         </div>
       </div>
     </footer>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -17,7 +17,7 @@ export default function Navbar() {
     );
 
     const observer = new IntersectionObserver(
-      (_entries) => {
+      () => {
         // Recheck all tracked sections on any change
         const anyVisible = darkSections.some((el) => {
           const rect = el.getBoundingClientRect();

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -4,30 +4,33 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 
+import { useLanguage } from "@/context/LanguageContext";
+import LanguageSwitcher from "@/components/ui/LanguageSwitcher";
+
 export default function Navbar() {
   const [isDarkTheme, setIsDarkTheme] = useState(false);
+  const { t } = useLanguage();
 
   useEffect(() => {
-    const handleScroll = () => {
-      let overDarkSection = false;
-      const headerOut = 80; // approximate height of header
-      
-      const darkElements = document.querySelectorAll<HTMLElement>('.manifesto, .beta-cta, footer');
-      darkElements.forEach(el => {
-        const rect = el.getBoundingClientRect();
-        if (rect.top <= headerOut && rect.bottom >= 40) {
-          overDarkSection = true;
-        }
-      });
-      
-      setIsDarkTheme(overDarkSection);
-    };
+    const darkSections = Array.from(
+      document.querySelectorAll<HTMLElement>('.manifesto, .beta-cta, footer')
+    );
 
-    window.addEventListener("scroll", handleScroll, { passive: true });
-    // Check initially in case page is reloaded halfway down
-    handleScroll();
-    
-    return () => window.removeEventListener("scroll", handleScroll);
+    const observer = new IntersectionObserver(
+      (_entries) => {
+        // Recheck all tracked sections on any change
+        const anyVisible = darkSections.some((el) => {
+          const rect = el.getBoundingClientRect();
+          return rect.top <= 80 && rect.bottom >= 40;
+        });
+        setIsDarkTheme(anyVisible);
+      },
+      { threshold: [0, 0.1], rootMargin: "-40px 0px -40px 0px" }
+    );
+
+    darkSections.forEach((el) => observer.observe(el));
+
+    return () => observer.disconnect();
   }, []);
 
   return (
@@ -37,22 +40,27 @@ export default function Navbar() {
           <Image src="/logo-flowe.png" alt="Flowē Logo" width={28} height={28} className="object-contain" priority />
           <span>Flowē<span>.</span></span>
         </Link>
-        <ul className="nav-links">
-          <li>
-            <Link href="#features">Features</Link>
-          </li>
-          <li>
-            <Link href="#compare">Why Flowē</Link>
-          </li>
-          <li>
-            <Link href="#updates">Updates</Link>
-          </li>
-          <li>
-            <Link href="#beta" className="nav-cta">
-              Join Beta →
-            </Link>
-          </li>
-        </ul>
+        <div className="flex items-center gap-6">
+          <ul className="nav-links">
+            <li>
+              <Link href="#features">{t.nav.features}</Link>
+            </li>
+            <li>
+              <Link href="#compare">{t.nav.whyFlowe}</Link>
+            </li>
+            <li>
+              <Link href="#updates">{t.nav.updates}</Link>
+            </li>
+          </ul>
+          
+          <div className="hidden md:block">
+            <LanguageSwitcher darkNavbar={isDarkTheme} />
+          </div>
+
+          <Link href="#beta" className="nav-cta">
+            {t.nav.joinBeta}
+          </Link>
+        </div>
       </nav>
     </header>
   );

--- a/src/components/layout/ShaderBackground.tsx
+++ b/src/components/layout/ShaderBackground.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useRef, useEffect, useState } from "react"
-import { Shader, Swirl, ChromaFlow } from "shaders/react"
+import { Shader, Swirl } from "shaders/react"
 
 export function ShaderBackground() {
   const [isLoaded, setIsLoaded] = useState(false)
@@ -46,29 +46,13 @@ export function ShaderBackground() {
       <Shader className="h-full w-full" dpr={1}>
         <Swirl
           colorA="#ffffff"
-          colorB="#5B8FB9" /* Original Primary */
+          colorB="#5B8FB9"
           speed={0.4}
           detail={0.7}
           blend={50}
-          opacity={0.4} /* Much lower opacity so it stays soft */
+          opacity={0.4}
         />
       </Shader>
-      <div className="absolute inset-0 opacity-60"> {/* Reduced overall layer opacity */}
-        <Shader className="h-full w-full" dpr={1}>
-          <ChromaFlow
-            baseColor="#ffffff"
-            upColor="#5B8FB9" /* Original Primary */
-            downColor="#ffffff"
-            leftColor="#E8C97D" /* Original Amber */
-            rightColor="#7BAE7F" /* Original Sage Green */
-            intensity={0.5} /* Reduced intensity to avoid deep saturation */
-            radius={1.8}
-            momentum={25}
-            maskType="alpha"
-            opacity={0.6}
-          />
-        </Shader>
-      </div>
     </div>
   )
 }

--- a/src/components/layout/ShaderBackground.tsx
+++ b/src/components/layout/ShaderBackground.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useRef, useEffect, useState } from "react"
-import { Shader, Swirl } from "shaders/react"
+import { Shader, Swirl, ChromaFlow } from "shaders/react"
 
 export function ShaderBackground() {
   const [isLoaded, setIsLoaded] = useState(false)
@@ -53,6 +53,22 @@ export function ShaderBackground() {
           opacity={0.4}
         />
       </Shader>
+      <div className="absolute inset-0 opacity-60">
+        <Shader className="h-full w-full" dpr={0.75}>
+          <ChromaFlow
+            baseColor="#ffffff"
+            upColor="#5B8FB9"
+            downColor="#ffffff"
+            leftColor="#E8C97D"
+            rightColor="#7BAE7F"
+            intensity={0.5}
+            radius={1.8}
+            momentum={25}
+            maskType="alpha"
+            opacity={0.6}
+          />
+        </Shader>
+      </div>
     </div>
   )
 }

--- a/src/components/sections/BetaCTA.tsx
+++ b/src/components/sections/BetaCTA.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useState } from "react";
+import { useLanguage } from "@/context/LanguageContext";
 
 export default function BetaCTA() {
   const [email, setEmail] = useState("");
   const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
+  const { t } = useLanguage();
 
   const handleSupportClick = () => {
     if (!email || !email.includes("@")) {
@@ -17,14 +19,12 @@ export default function BetaCTA() {
   return (
     <section className="beta-cta" id="beta">
       <div className="beta-inner">
-        <h2 className="beta-title reveal">
-          Be part of<br />
-          <em>the first wave.</em>
-        </h2>
+        <h2 
+          className="beta-title reveal"
+          dangerouslySetInnerHTML={{ __html: t.beta.title }}
+        />
         <p className="beta-body reveal">
-          Join the Flowē beta and help shape the app. You'll get early access,
-          a direct line to the team, and be the first to experience every new
-          feature.
+          {t.beta.body}
         </p>
 
         {status !== "success" ? (
@@ -32,7 +32,7 @@ export default function BetaCTA() {
             <input
               type="email"
               className="email-input"
-              placeholder="your@email.com"
+              placeholder={t.beta.placeholder}
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               onKeyDown={(e) => {
@@ -44,7 +44,7 @@ export default function BetaCTA() {
               }}
             />
             <button className="btn-rose" onClick={handleSupportClick}>
-              Join Beta →
+              {t.beta.button}
             </button>
           </div>
         ) : (
@@ -52,33 +52,26 @@ export default function BetaCTA() {
             className="form-success reveal visible"
             style={{ display: "flex", animation: "fadeUp 0.5s ease both" }}
           >
-            <span>✓</span> You're on the list! We'll be in touch soon.
+            <span>✓</span> {t.beta.success}
           </div>
         )}
 
         {status === "error" && (
           <p style={{ color: "rgba(91,143,185,0.8)", fontSize: "0.8rem", marginTop: "-0.5rem", marginBottom: "1rem" }}>
-            Please enter a valid email
+            {t.beta.error}
           </p>
         )}
 
         <p className="beta-note reveal">
-          We respect your inbox. No spam, ever.
+          {t.beta.note}
         </p>
 
         <div className="beta-perks reveal">
-          <div className="beta-perk">
-            <span className="perk-check">✓</span> Free during beta
-          </div>
-          <div className="beta-perk">
-            <span className="perk-check">✓</span> Android & iOS
-          </div>
-          <div className="beta-perk">
-            <span className="perk-check">✓</span> Shape the product
-          </div>
-          <div className="beta-perk">
-            <span className="perk-check">✓</span> Discord community
-          </div>
+          {t.beta.perks.map((perk, index) => (
+            <div key={index} className="beta-perk">
+              <span className="perk-check">✓</span> {perk}
+            </div>
+          ))}
         </div>
       </div>
     </section>

--- a/src/components/sections/Compare.tsx
+++ b/src/components/sections/Compare.tsx
@@ -1,106 +1,48 @@
+import { useLanguage } from "@/context/LanguageContext";
+
 export default function Compare() {
+  const { t } = useLanguage();
+  
   return (
     <section className="compare" id="compare">
       <div className="container">
         <div className="reveal">
-          <p className="section-eyebrow">Why Flowē</p>
-          <h2 className="section-title">
-            The app Tiimo
-            <br />
-            isn't giving you
-          </h2>
+          <p className="section-eyebrow">{t.compare.eyebrow}</p>
+          <h2 
+            className="section-title"
+            dangerouslySetInnerHTML={{ __html: t.compare.title }}
+          />
           <p className="section-body">
-            We built Flowē because great tools shouldn't be exclusive to iOS
-            users in wealthy countries.
+            {t.compare.body}
           </p>
         </div>
 
         <div className="compare-header reveal">
           <div className="compare-col-head">
-            <div className="compare-brand">Feature</div>
+            <div className="compare-brand">{t.compare.header[0]}</div>
           </div>
           <div className="compare-col-head">
-            <div className="compare-brand">Tiimo</div>
-            <div className="compare-tagline">iOS · €/month</div>
+            <div className="compare-brand">{t.compare.header[1]}</div>
+            <div className="compare-tagline">{t.compare.subtitles[0]}</div>
           </div>
           <div className="compare-col-head flowe">
-            <div className="compare-brand flowe-brand">Flowē</div>
-            <div className="compare-tagline">Android + iOS · LATAM pricing</div>
+            <div className="compare-brand flowe-brand">{t.compare.header[2]}</div>
+            <div className="compare-tagline">{t.compare.subtitles[1]}</div>
           </div>
         </div>
 
         <div className="compare-body reveal">
-          <div className="compare-row">
-            <div className="compare-cell feature-name">Android support</div>
-            <div className="compare-cell">
-              <span className="cross">✕</span> iOS only
+          {t.compare.rows.map((row, index) => (
+            <div key={index} className="compare-row">
+              <div className="compare-cell feature-name">{row.name}</div>
+              <div className="compare-cell">
+                {!row.check && <span className="cross">✕</span>} {row.tiimo}
+              </div>
+              <div className="compare-cell flowe-cell">
+                {row.check && <span className="check">✓</span>} {row.flowe}
+              </div>
             </div>
-            <div className="compare-cell flowe-cell">
-              <span className="check">✓</span> Yes
-            </div>
-          </div>
-          <div className="compare-row">
-            <div className="compare-cell feature-name">LATAM pricing</div>
-            <div className="compare-cell">
-              <span className="cross">✕</span> ~$10–15/mo
-            </div>
-            <div className="compare-cell flowe-cell">
-              <span className="check">✓</span> Affordable tiers
-            </div>
-          </div>
-          <div className="compare-row">
-            <div className="compare-cell feature-name">
-              Adaptive AI routines
-            </div>
-            <div className="compare-cell">
-              <span className="cross">✕</span> Static
-            </div>
-            <div className="compare-cell flowe-cell">
-              <span className="check">✓</span> Learns your patterns
-            </div>
-          </div>
-          <div className="compare-row">
-            <div className="compare-cell feature-name">
-              AI task decomposition
-            </div>
-            <div className="compare-cell">
-              <span className="cross">✕</span> No
-            </div>
-            <div className="compare-cell flowe-cell">
-              <span className="check">✓</span> Yes
-            </div>
-          </div>
-          <div className="compare-row">
-            <div className="compare-cell feature-name">
-              Emotional check-ins
-            </div>
-            <div className="compare-cell">
-              <span className="cross">✕</span> No
-            </div>
-            <div className="compare-cell flowe-cell">
-              <span className="check">✓</span> Yes
-            </div>
-          </div>
-          <div className="compare-row">
-            <div className="compare-cell feature-name">
-              Spanish-first support
-            </div>
-            <div className="compare-cell">
-              <span className="cross">✕</span> English only
-            </div>
-            <div className="compare-cell flowe-cell">
-              <span className="check">✓</span> ES + EN
-            </div>
-          </div>
-          <div className="compare-row">
-            <div className="compare-cell feature-name">Open beta</div>
-            <div className="compare-cell">
-              <span className="cross">✕</span> Waitlist
-            </div>
-            <div className="compare-cell flowe-cell">
-              <span className="check">✓</span> Free beta access
-            </div>
-          </div>
+          ))}
         </div>
       </div>
     </section>

--- a/src/components/sections/Features.tsx
+++ b/src/components/sections/Features.tsx
@@ -1,93 +1,48 @@
+import { useLanguage } from "@/context/LanguageContext";
+import { WaveIcon, PaletteIcon, ChatIcon, BellIcon, RobotIcon, MoonIcon } from "@/components/ui/Icons";
+
+const FEATURE_ICONS = [
+  <WaveIcon key="wave" />,
+  <PaletteIcon key="palette" />,
+  <ChatIcon key="chat" />,
+  <BellIcon key="bell" />,
+  <RobotIcon key="robot" />,
+  <MoonIcon key="moon" />
+];
+
 export default function Features() {
+  const { t } = useLanguage();
+  
   return (
     <section className="features" id="features">
       <div className="container">
         <div className="reveal">
-          <p className="section-eyebrow">What makes Flowē different</p>
-          <h2 className="section-title">
-            Built around
-            <br />
-            how you think
-          </h2>
+          <p className="section-eyebrow">{t.features.eyebrow}</p>
+          <h2 
+            className="section-title"
+            dangerouslySetInnerHTML={{ __html: t.features.title }}
+          />
           <p className="section-body">
-            No rigid systems, no guilt-tripping streaks. Just a calm, flexible
-            tool that learns your patterns.
+            {t.features.body}
           </p>
         </div>
 
         <div className="features-grid">
-          <div className="feature-card rose reveal">
-            <div className="feature-icon rose">🌊</div>
-            <h3 className="feature-title">Adaptive Routines</h3>
-            <p className="feature-body">
-              AI learns your energy patterns across the day and week. Bad sleep
-              last night? Flowē adjusts your morning routine automatically — no
-              willpower needed.
-            </p>
-          </div>
-
-          <div
-            className="feature-card sage reveal"
-            style={{ transitionDelay: "0.1s" }}
-          >
-            <div className="feature-icon sage">🎨</div>
-            <h3 className="feature-title">Visual Timelines</h3>
-            <p className="feature-body">
-              See your day at a glance with color-coded, icon-rich visual
-              schedules. Designed specifically for minds that think in pictures,
-              not lists.
-            </p>
-          </div>
-
-          <div
-            className="feature-card lavender reveal"
-            style={{ transitionDelay: "0.2s" }}
-          >
-            <div className="feature-icon lavender">💬</div>
-            <h3 className="feature-title">Emotional Check-ins</h3>
-            <p className="feature-body">
-              A gentle pulse check before high-demand tasks. Flowē notices when
-              you're overwhelmed and suggests breaks, modifications, or shorter
-              alternatives.
-            </p>
-          </div>
-
-          <div
-            className="feature-card sage reveal"
-            style={{ transitionDelay: "0.3s" }}
-          >
-            <div className="feature-icon sage">🔔</div>
-            <h3 className="feature-title">Gentle Reminders</h3>
-            <p className="feature-body">
-              No harsh buzzers or red notifications. Soft, non-anxiety-inducing
-              nudges that feel like a kind friend — not a school bell.
-            </p>
-          </div>
-
-          <div
-            className="feature-card rose reveal"
-            style={{ transitionDelay: "0.4s" }}
-          >
-            <div className="feature-icon rose">🤖</div>
-            <h3 className="feature-title">AI Task Decomposition</h3>
-            <p className="feature-body">
-              Type "Write my report" and Flowē breaks it into 5-minute
-              micro-steps. The overwhelm disappears. The doing begins.
-            </p>
-          </div>
-
-          <div
-            className="feature-card lavender reveal"
-            style={{ transitionDelay: "0.5s" }}
-          >
-            <div className="feature-icon lavender">🌙</div>
-            <h3 className="feature-title">Wind-Down Mode</h3>
-            <p className="feature-body">
-              A structured end-of-day ritual that helps your brain transition
-              out of hyperfocus and actually rest. Sleep hygiene,
-              neurodivergent-style.
-            </p>
-          </div>
+          {t.features.items.map((item, index) => (
+            <div 
+              key={index}
+              className={`feature-card ${index === 2 || index === 5 ? 'lavender' : index === 1 || index === 3 ? 'sage' : 'rose'} reveal`}
+              style={{ transitionDelay: `${index * 0.1}s` }}
+            >
+              <div className={`feature-icon ${index === 2 || index === 5 ? 'lavender' : index === 1 || index === 3 ? 'sage' : 'rose'}`}>
+                {FEATURE_ICONS[index]}
+              </div>
+              <h3 className="feature-title">{item.title}</h3>
+              <p className="feature-body">
+                {item.body}
+              </p>
+            </div>
+          ))}
         </div>
       </div>
     </section>

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,4 +1,8 @@
+import { useLanguage } from "@/context/LanguageContext";
+
 export default function Hero() {
+  const { t } = useLanguage();
+  
   return (
     <section className="hero">
       <div className="hero-blob blob-1"></div>
@@ -6,18 +10,17 @@ export default function Hero() {
       <div className="hero-blob blob-3"></div>
 
       <h1 className="hero-title">
-        <span className="word-your">Your</span> <span className="word-rhythm">rhythm,</span><br />
-        <em>your flow.</em>
+        <span className="word-your">{t.hero.your}</span> <span className="word-rhythm">{t.hero.rhythm}</span><br />
+        <em>{t.hero.yourFlow}</em>
       </h1>
 
       <p className="hero-sub">
-        A routines app designed for the way your brain actually works — with
-        adaptive AI, visual schedules, and zero overwhelm.
+        {t.hero.sub}
       </p>
 
       <div className="hero-actions">
         <a href="#beta" className="btn-minimal">
-          Join the Beta ⟶
+          {t.hero.cta}
         </a>
       </div>
 
@@ -34,12 +37,12 @@ export default function Hero() {
                 </div>
               </div>
               <div className="phone-content">
-                <div className="phone-greeting">Good morning, Alex ✦</div>
-                <div className="phone-sub">Your flow looks great today</div>
+                <div className="phone-greeting">{t.hero.mockup.greeting}</div>
+                <div className="phone-sub">{t.hero.mockup.sub}</div>
 
                 <div className="phone-card">
-                  <div className="phone-card-label">Morning Routine</div>
-                  <div className="phone-card-title">3 of 5 complete</div>
+                  <div className="phone-card-label">{t.hero.mockup.morningRoutine}</div>
+                  <div className="phone-card-title">3 of 5 {t.hero.mockup.complete}</div>
                   <div className="phone-progress-bar">
                     <div className="phone-progress-fill"></div>
                   </div>
@@ -48,17 +51,17 @@ export default function Hero() {
                 <div className="phone-tasks">
                   <div className="phone-task">
                     <div className="task-dot rose"></div>
-                    <span className="task-text">Take medication</span>
+                    <span className="task-text">{t.hero.mockup.tasks.meds}</span>
                     <span className="task-time">✓ 8:05</span>
                   </div>
                   <div className="phone-task">
                     <div className="task-dot sage"></div>
-                    <span className="task-text">15 min movement</span>
-                    <span className="task-time">Now</span>
+                    <span className="task-text">{t.hero.mockup.tasks.movement}</span>
+                    <span className="task-time">{t.hero.mockup.tasks.now}</span>
                   </div>
                   <div className="phone-task">
                     <div className="task-dot lavender"></div>
-                    <span className="task-text">Deep work session</span>
+                    <span className="task-text">{t.hero.mockup.tasks.deepWork}</span>
                     <span className="task-time">10:00</span>
                   </div>
                 </div>
@@ -66,13 +69,13 @@ export default function Hero() {
             </div>
           </div>
           <div className="hero-chip chip-left">
-            <span className="chip-emoji">🧠</span> ADHD-friendly
+            <span className="chip-emoji">🧠</span> {t.hero.chips.adhd}
           </div>
           <div className="hero-chip chip-right">
-            <span className="chip-emoji">✨</span> AI adapts to you
+            <span className="chip-emoji">✨</span> {t.hero.chips.ai}
           </div>
           <div className="hero-chip chip-bottom">
-            <span className="chip-emoji">🌍</span> Made for LATAM
+            <span className="chip-emoji">🌍</span> {t.hero.chips.latam}
           </div>
         </div>
       </div>

--- a/src/components/sections/Manifesto.tsx
+++ b/src/components/sections/Manifesto.tsx
@@ -1,16 +1,17 @@
+import { useLanguage } from "@/context/LanguageContext";
+
 export default function Manifesto() {
+  const { t } = useLanguage();
+
   return (
     <section className="manifesto">
       <div className="container">
-        <p className="manifesto-quote">
-          "Productivity tools were built for <em>neurotypical brains.</em>
-          <br />
-          We built Flowē for everyone else."
-        </p>
+        <p 
+          className="manifesto-quote"
+          dangerouslySetInnerHTML={{ __html: t.manifesto.quote }}
+        />
         <p className="manifesto-body">
-          ADHD, autism, dyslexia — these aren't limitations. They're different
-          operating systems. Flowē speaks your language, adapts to your energy,
-          and builds routines that actually stick.
+          {t.manifesto.body}
         </p>
       </div>
     </section>

--- a/src/components/sections/Testimonials.tsx
+++ b/src/components/sections/Testimonials.tsx
@@ -1,70 +1,41 @@
+import { useLanguage } from "@/context/LanguageContext";
+
 export default function Testimonials() {
+  const { t } = useLanguage();
+  
   return (
     <section className="testimonials">
       <div className="container">
         <div className="reveal">
-          <p className="section-eyebrow">From the community</p>
-          <h2 className="section-title">
-            What beta testers
-            <br />
-            are already saying
-          </h2>
+          <p className="section-eyebrow">{t.testimonials.eyebrow}</p>
+          <h2 
+            className="section-title"
+            dangerouslySetInnerHTML={{ __html: t.testimonials.title }}
+          />
         </div>
 
         <div className="testimonials-grid">
-          <div className="testimonial-card reveal">
-            <div className="testimonial-quote-mark">"</div>
-            <p className="testimonial-text">
-              Finally an app that doesn't make me feel bad for not completing my
-              tasks. The AI just... adapts. It felt like it understood me on the
-              first day.
-            </p>
-            <div className="testimonial-author">
-              <div className="author-avatar av-1">M</div>
-              <div>
-                <div className="author-name">Mariana R.</div>
-                <div className="author-label">ADHD · México DF</div>
+          {t.testimonials.items.map((item, index) => (
+            <div 
+              key={index}
+              className="testimonial-card reveal"
+              style={{ transitionDelay: `${index * 0.1}s` }}
+            >
+              <div className="testimonial-quote-mark">"</div>
+              <p className="testimonial-text">
+                {item.text}
+              </p>
+              <div className="testimonial-author">
+                <div className={`author-avatar av-${index + 1}`}>
+                  {item.name.charAt(0)}
+                </div>
+                <div>
+                  <div className="author-name">{item.name}</div>
+                  <div className="author-label">{item.label}</div>
+                </div>
               </div>
             </div>
-          </div>
-
-          <div
-            className="testimonial-card reveal"
-            style={{ transitionDelay: "0.1s" }}
-          >
-            <div className="testimonial-quote-mark">"</div>
-            <p className="testimonial-text">
-              I've tried every productivity app. Flowē is the first one I didn't
-              uninstall after a week. The visual timeline is exactly how my
-              brain needs to see time.
-            </p>
-            <div className="testimonial-author">
-              <div className="author-avatar av-2">D</div>
-              <div>
-                <div className="author-name">Diego A.</div>
-                <div className="author-label">Autism + ADHD · Bogotá</div>
-              </div>
-            </div>
-          </div>
-
-          <div
-            className="testimonial-card reveal"
-            style={{ transitionDelay: "0.2s" }}
-          >
-            <div className="testimonial-quote-mark">"</div>
-            <p className="testimonial-text">
-              Tiimo was too expensive and wasn't even on Android. Flowē does
-              more, costs less, and the dev actually listens in the Discord.
-              This is the one.
-            </p>
-            <div className="testimonial-author">
-              <div className="author-avatar av-3">S</div>
-              <div>
-                <div className="author-name">Sofía V.</div>
-                <div className="author-label">Dyslexia · San José, CR</div>
-              </div>
-            </div>
-          </div>
+          ))}
         </div>
       </div>
     </section>

--- a/src/components/sections/Updates.tsx
+++ b/src/components/sections/Updates.tsx
@@ -1,71 +1,42 @@
+import { useLanguage } from "@/context/LanguageContext";
+
 export default function Updates() {
+  const { t } = useLanguage();
+  
   return (
     <section className="updates" id="updates">
       <div className="container">
         <div className="reveal">
-          <p className="section-eyebrow">Dev updates</p>
-          <h2 className="section-title">Built in public</h2>
+          <p className="section-eyebrow">{t.updates.eyebrow}</p>
+          <h2 className="section-title">{t.updates.title}</h2>
           <p className="section-body">
-            Follow the journey from idea to product. We share everything —
-            decisions, learnings, and honest progress.
+            {t.updates.body}
           </p>
         </div>
 
         <div className="updates-grid">
-          <a href="#" className="update-card reveal">
-            <div className="update-banner rose-bg">🌊</div>
-            <div className="update-body">
-              <div className="update-tag">Announcement</div>
-              <div className="update-title">
-                Flowē is officially in development
+          {t.updates.posts.map((post, index) => (
+            <a 
+              key={index}
+              href="#" 
+              className="update-card reveal"
+              style={{ transitionDelay: `${index * 0.1}s` }}
+            >
+              <div className={`update-banner ${index === 2 ? 'lav-bg' : index === 1 ? 'sage-bg' : 'rose-bg'}`}>
+                {index === 2 ? '🎨' : index === 1 ? '🤖' : '🌊'}
               </div>
-              <div className="update-excerpt">
-                Introducing Flowē — a Flutter app for neurodivergent people who
-                deserve better tools. Here's why we're building it and who it's
-                for.
+              <div className="update-body">
+                <div className="update-tag">{post.tag}</div>
+                <div className="update-title">
+                  {post.title}
+                </div>
+                <div className="update-excerpt">
+                  {post.excerpt}
+                </div>
+                <div className="update-date">{post.date}</div>
               </div>
-              <div className="update-date">March 2025</div>
-            </div>
-          </a>
-
-          <a
-            href="#"
-            className="update-card reveal"
-            style={{ transitionDelay: "0.1s" }}
-          >
-            <div className="update-banner sage-bg">🤖</div>
-            <div className="update-body">
-              <div className="update-tag">Feature Preview</div>
-              <div className="update-title">
-                How the AI adaptive engine works
-              </div>
-              <div className="update-excerpt">
-                A deep dive into our RAG-powered routine engine — how Flowē
-                learns your patterns without ever storing sensitive data.
-              </div>
-              <div className="update-date">March 2025</div>
-            </div>
-          </a>
-
-          <a
-            href="#"
-            className="update-card reveal"
-            style={{ transitionDelay: "0.2s" }}
-          >
-            <div className="update-banner lav-bg">🎨</div>
-            <div className="update-body">
-              <div className="update-tag">Design</div>
-              <div className="update-title">
-                Designing for neurodivergent users: what we learned
-              </div>
-              <div className="update-excerpt">
-                Our UX research process, the principles we adopted, and why
-                most productivity apps fail this community from the first
-                onboarding screen.
-              </div>
-              <div className="update-date">Coming soon</div>
-            </div>
-          </a>
+            </a>
+          ))}
         </div>
       </div>
     </section>

--- a/src/components/ui/Icons.tsx
+++ b/src/components/ui/Icons.tsx
@@ -1,0 +1,73 @@
+export const TwitterIcon = () => (
+  <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
+    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.045 4.126H5.078z" />
+  </svg>
+);
+
+export const InstagramIcon = () => (
+  <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect>
+    <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path>
+    <line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line>
+  </svg>
+);
+
+export const DiscordIcon = () => (
+  <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
+    <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-0.079.037c-0.21.375-0.444.864-0.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-0.617-1.25.077.077 0 0 0-0.079-0.037 19.736 19.736 0 0 0-4.885 1.515.069.069 0 0 0-0.032.027C0.533 9.048-0.32 13.572 0.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-0.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-0.041-0.106 13.107 13.107 0 0 1-1.872-0.892.077.077 0 0 1-0.008-0.128 10.2 10.2 0 0 0 .372-0.292.074.074 0 0 1 .077-0.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-0.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 1-0.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-0.054c.5-5.177-0.838-9.674-3.549-13.66a.061.061 0 0 0-0.031-0.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
+  </svg>
+);
+
+export const GithubIcon = () => (
+  <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
+    <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+  </svg>
+);
+
+export const WaveIcon = () => (
+  <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M2 6c.6.5 1.2 1 2.5 1C7 7 7 5 9.5 5c2.6 0 2.4 2 5 2 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1"></path>
+    <path d="M2 12c.6.5 1.2 1 2.5 1 2.5 0 2.5-2 5-2 2.6 0 2.4 2 5 2 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1"></path>
+    <path d="M2 18c.6.5 1.2 1 2.5 1 2.5 0 2.5-2 5-2 2.6 0 2.4 2 5 2 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1"></path>
+  </svg>
+);
+
+export const PaletteIcon = () => (
+  <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="13.5" cy="6.5" r=".5"></circle>
+    <circle cx="17.5" cy="10.5" r=".5"></circle>
+    <circle cx="8.5" cy="7.5" r=".5"></circle>
+    <circle cx="6.5" cy="12.5" r=".5"></circle>
+    <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.9 0 1.5-.6 1.5-1.5 0-.4-.1-.8-.4-1.1-.3-.3-.4-.7-.4-1.1 0-.9.7-1.5 1.5-1.5H16c3.3 0 6-2.7 6-6 0-4.9-4.5-9-10-9z"></path>
+  </svg>
+);
+
+export const ChatIcon = () => (
+  <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="m3 21 1.9-5.7a8.5 8.5 0 1 1 3.8 3.8z"></path>
+  </svg>
+);
+
+export const BellIcon = () => (
+  <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"></path>
+    <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0"></path>
+  </svg>
+);
+
+export const RobotIcon = () => (
+  <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M12 8V4H8"></path>
+    <rect width="16" height="12" x="4" y="8" rx="2"></rect>
+    <path d="M2 14h2"></path>
+    <path d="M20 14h2"></path>
+    <path d="M15 13v2"></path>
+    <path d="M9 13v2"></path>
+  </svg>
+);
+
+export const MoonIcon = () => (
+  <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"></path>
+  </svg>
+);

--- a/src/components/ui/LanguageSwitcher.tsx
+++ b/src/components/ui/LanguageSwitcher.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useLanguage } from "@/context/LanguageContext";
+import { motion } from "framer-motion";
+
+interface LanguageSwitcherProps {
+  darkNavbar?: boolean;
+}
+
+export default function LanguageSwitcher({ darkNavbar = false }: LanguageSwitcherProps) {
+  const { locale, setLocale } = useLanguage();
+
+  return (
+    <div 
+      className={`relative flex items-center p-1 rounded-full border border-white/20 backdrop-blur-md transition-all duration-300 cursor-pointer w-[100px] h-[34px] overflow-hidden ${
+        darkNavbar 
+          ? "bg-black/20" 
+          : "bg-white/30 shadow-[0_4px_12px_rgba(31,38,135,0.07)]"
+      }`}
+      onClick={() => setLocale(locale === "en" ? "es" : "en")}
+    >
+      {/* Background Pill - The Glass Slide */}
+      <motion.div
+        className={`absolute h-[calc(100%-8px)] w-[calc(50%-4px)] rounded-full z-0 border border-white/40 shadow-sm ${
+          darkNavbar ? "bg-white/20" : "bg-white/80"
+        }`}
+        initial={false}
+        animate={{ x: locale === "en" ? 0 : "100%" }}
+        transition={{ type: "spring", stiffness: 450, damping: 35 }}
+      />
+      
+      {/* Labels */}
+      <div className="relative flex w-full justify-between items-center z-10">
+        <span 
+          className={`flex-1 text-center text-[10px] font-black tracking-widest transition-colors duration-300 ${
+            locale === "en" 
+              ? (darkNavbar ? "text-white" : "text-slate-900") 
+              : (darkNavbar ? "text-white/40" : "text-slate-500/60")
+          }`}
+        >
+          EN
+        </span>
+        <span 
+          className={`flex-1 text-center text-[10px] font-black tracking-widest transition-colors duration-300 ${
+            locale === "es" 
+              ? (darkNavbar ? "text-white" : "text-slate-900") 
+              : (darkNavbar ? "text-white/40" : "text-slate-500/60")
+          }`}
+        >
+          ES
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import React, { createContext, useContext, useState, useEffect } from "react";
+import { en, es, Translations } from "@/lib/translations";
+
+type Locale = "en" | "es";
+
+interface LanguageContextProps {
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+  t: Translations;
+}
+
+const LanguageContext = createContext<LanguageContextProps | undefined>(undefined);
+
+export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [locale, setLocale] = useState<Locale>("en");
+
+  useEffect(() => {
+    const savedLocale = localStorage.getItem("flowe-locale") as Locale;
+    if (savedLocale && (savedLocale === "en" || savedLocale === "es")) {
+      setLocale(savedLocale);
+    } else {
+      const browserLocale = navigator.language.split("-")[0];
+      if (browserLocale === "es") {
+        setLocale("es");
+      }
+    }
+  }, []);
+
+  const changeLocale = (newLocale: Locale) => {
+    setLocale(newLocale);
+    localStorage.setItem("flowe-locale", newLocale);
+    document.documentElement.lang = newLocale;
+  };
+
+  const t = locale === "es" ? es : en;
+
+  return (
+    <LanguageContext.Provider value={{ locale, setLocale: changeLocale, t }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+export const useLanguage = () => {
+  const context = useContext(LanguageContext);
+  if (!context) {
+    throw new Error("useLanguage must be used within a LanguageProvider");
+  }
+  return context;
+};

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { createContext, useContext, useState, useEffect } from "react";
+import React, { createContext, useContext, useState } from "react";
 import { en, es, Translations } from "@/lib/translations";
 
 type Locale = "en" | "es";
@@ -14,19 +14,12 @@ interface LanguageContextProps {
 const LanguageContext = createContext<LanguageContextProps | undefined>(undefined);
 
 export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [locale, setLocale] = useState<Locale>("en");
-
-  useEffect(() => {
-    const savedLocale = localStorage.getItem("flowe-locale") as Locale;
-    if (savedLocale && (savedLocale === "en" || savedLocale === "es")) {
-      setLocale(savedLocale);
-    } else {
-      const browserLocale = navigator.language.split("-")[0];
-      if (browserLocale === "es") {
-        setLocale("es");
-      }
-    }
-  }, []);
+  const [locale, setLocale] = useState<Locale>(() => {
+    if (typeof window === "undefined") return "en";
+    const saved = localStorage.getItem("flowe-locale");
+    if (saved === "en" || saved === "es") return saved;
+    return navigator.language.startsWith("es") ? "es" : "en";
+  });
 
   const changeLocale = (newLocale: Locale) => {
     setLocale(newLocale);

--- a/src/lib/translations/index.ts
+++ b/src/lib/translations/index.ts
@@ -1,0 +1,319 @@
+export const en = {
+  nav: {
+    features: "Features",
+    whyFlowe: "Why Flowē",
+    updates: "Updates",
+    joinBeta: "Join Beta →",
+  },
+  hero: {
+    your: "Your",
+    rhythm: "rhythm,",
+    yourFlow: "your flow.",
+    sub: "A routines app designed for the way your brain actually works — with adaptive AI, visual schedules, and zero overwhelm.",
+    cta: "Join the Beta ⟶",
+    mockup: {
+      greeting: "Good morning, Alex ✦",
+      sub: "Your flow looks great today",
+      morningRoutine: "Morning Routine",
+      complete: "completed",
+      tasks: {
+        meds: "Take medication",
+        movement: "15 min movement",
+        deepWork: "Deep work session",
+        now: "Now"
+      }
+    },
+    chips: {
+      adhd: "ADHD-friendly",
+      ai: "AI adapts to you",
+      latam: "Global access"
+    }
+  },
+  manifesto: {
+    quote: '"Productivity tools were built for <em>neurotypical brains.</em><br>We built Flowē for everyone else."',
+    body: "ADHD, autism, dyslexia — these aren't limitations. They're different operating systems. Flowē speaks your language, adapts to your energy, and builds routines that actually stick."
+  },
+  features: {
+    eyebrow: "What makes Flowē different",
+    title: "Built around<br />how you think",
+    body: "No rigid systems, no guilt-tripping streaks. Just a calm, flexible tool that learns your patterns.",
+    items: [
+      {
+        title: "Adaptive Routines",
+        body: "AI learns your energy patterns across the day and week. Bad sleep last night? Flowē adjusts your morning routine automatically — no willpower needed."
+      },
+      {
+        title: "Visual Timelines",
+        body: "See your day at a glance with color-coded, icon-rich visual schedules. Designed specifically for minds that think in pictures, not lists."
+      },
+      {
+        title: "Emotional Check-ins",
+        body: "A gentle pulse check before high-demand tasks. Flowē notices when you're overwhelmed and suggests breaks, modifications, or shorter alternatives."
+      },
+      {
+        title: "Gentle Reminders",
+        body: "No harsh buzzers or red notifications. Soft, non-anxiety-inducing nudges that feel like a kind friend — not a school bell."
+      },
+      {
+        title: "AI Task Decomposition",
+        body: "Type \"Write my report\" and Flowē breaks it into 5-minute micro-steps. The overwhelm disappears. The doing begins."
+      },
+      {
+        title: "Wind-Down Mode",
+        body: "A structured end-of-day ritual that helps your brain transition out of hyperfocus and actually rest. Sleep hygiene, neurodivergent-style."
+      }
+    ]
+  },
+  compare: {
+    eyebrow: "The Flowē Advantage",
+    title: "The standard others<br />aren't meeting",
+    body: "We built Flowē to be the most accessible and intelligent routine engine ever made, regardless of your platform or location.",
+    header: ["Feature", "Competitors", "Flowē"],
+    subtitles: ["Limited platforms", "Universal access"],
+    rows: [
+      { name: "Platform Support", tiimo: "iOS mostly", flowe: "Android + iOS + Web", check: true },
+      { name: "Subscription", tiimo: "Static high-tier", flowe: "Fair global pricing", check: true },
+      { name: "Adaptive AI routines", tiimo: "Manual strictly", flowe: "Learns your patterns", check: true },
+      { name: "AI task decomposition", tiimo: "No", flowe: "Yes", check: true },
+      { name: "Emotional check-ins", tiimo: "No", flowe: "Yes", check: true },
+      { name: "Multi-language Support", tiimo: "English only", flowe: "Native ES + EN", check: true },
+      { name: "Open beta", tiimo: "Waitlist", flowe: "Immediate access", check: true }
+    ]
+  },
+  testimonials: {
+    eyebrow: "From the community",
+    title: "What beta testers<br />are already saying",
+    items: [
+      {
+        text: "Finally an app that doesn't make me feel bad for not completing my tasks. The AI just... adapts. It felt like it understood me on the first day.",
+        name: "Mariana R.",
+        label: "ADHD"
+      },
+      {
+        text: "I've tried every productivity app. Flowē is the first one I didn't uninstall after a week. The visual timeline is exactly how my brain needs to see time.",
+        name: "Diego A.",
+        label: "Autism + ADHD"
+      },
+      {
+        text: "Other tools were too expensive or platform-locked. Flowē does more, costs less, and the dev actually listens in the Discord. This is the one.",
+        name: "Sofía V.",
+        label: "Dyslexia"
+      }
+    ]
+  },
+  updates: {
+    eyebrow: "Dev updates",
+    title: "Built in public",
+    body: "Follow the journey from idea to product. We share everything — decisions, learnings, and honest progress.",
+    posts: [
+      {
+        tag: "Announcement",
+        title: "Flowē is officially in development",
+        excerpt: "Introducing Flowē — a Flutter app for neurodivergent people who deserve better tools. Here's why we're building it and who it's for.",
+        date: "March 2026"
+      },
+      {
+        tag: "Feature Preview",
+        title: "How the AI adaptive engine works",
+        excerpt: "A deep dive into our RAG-powered routine engine — how Flowē learns your patterns without ever storing sensitive data.",
+        date: "March 2026"
+      },
+      {
+        tag: "Design",
+        title: "Designing for neurodivergent users: what we learned",
+        excerpt: "Our UX research process, the principles we adopted, and why most productivity apps fail this community from the first onboarding screen.",
+        date: "Coming soon"
+      }
+    ]
+  },
+  beta: {
+    title: "Be part of<br /><em>the first wave.</em>",
+    body: "Join the Flowē beta and help shape the app. You'll get early access, a direct line to the team, and be the first to experience every new feature.",
+    placeholder: "your@email.com",
+    button: "Join Beta →",
+    success: "You're on the list! We'll be in touch soon.",
+    error: "Please enter a valid email",
+    note: "We respect your inbox. No spam, ever.",
+    perks: ["Free during beta", "Android & iOS", "Shape the product", "Discord community"]
+  },
+  footer: {
+    tagline: "Your rhythm, your flow.<br />A productivity app for neurodivergent minds.",
+    cols: {
+      product: {
+        title: "Product",
+        links: ["Features", "Why Flowē", "Join Beta", "Roadmap"]
+      },
+      updates: {
+        title: "Updates",
+        links: ["Blog", "Changelog", "Dev Notes", "Newsletter"]
+      },
+      info: {
+        title: "Info",
+        links: ["About", "Privacy Policy", "Terms", "Contact"]
+      }
+    },
+    copy: "© 2026 Flowē. All rights reserved.",
+    made: "Made with care 🌍"
+  }
+};
+
+export const es = {
+  nav: {
+    features: "Funciones",
+    whyFlowe: "Por qué Flowē",
+    updates: "Novedades",
+    joinBeta: "Unirse al Beta →",
+  },
+  hero: {
+    your: "A tu",
+    rhythm: "ritmo,",
+    yourFlow: "a tu manera.",
+    sub: "Una app de rutinas diseñada para la forma en que tu cerebro realmente funciona — con IA adaptativa, horarios visuales y cero abrumación.",
+    cta: "Únete al Beta ⟶",
+    mockup: {
+      greeting: "¡Buen día, Alex! ✦",
+      sub: "Tu flow se ve genial hoy",
+      morningRoutine: "Rutina Mañanera",
+      complete: "completados",
+      tasks: {
+        meds: "Tomar medicación",
+        movement: "15 min de movimiento",
+        deepWork: "Sesión de trabajo profundo",
+        now: "Ahora"
+      }
+    },
+    chips: {
+      adhd: "Pensado para TDAH",
+      ai: "La IA se adapta a ti",
+      latam: "Acceso global"
+    }
+  },
+  manifesto: {
+    quote: '"Las herramientas de productividad fueron hechas para <em>cerebros neurotípicos.</em><br>Hicimos Flowē para todos los demás."',
+    body: "TDAH, autismo, dislexia — no son limitaciones. Son sistemas operativos diferentes. Flowē habla tu idioma, se adapta a tu energía y crea rutinas que realmente funcionan."
+  },
+  features: {
+    eyebrow: "Qué hace diferente a Flowē",
+    title: "Hecho a medida de<br />cómo piensas",
+    body: "Sin sistemas rígidos ni rachas que causen culpa. Solo una herramienta calma y flexible que aprende tus patrones.",
+    items: [
+      {
+        title: "Rutinas Adaptativas",
+        body: "La IA aprende tus niveles de energía durante el día y la semana. ¿Dormiste mal? Flowē ajusta tu rutina automáticamente — sin esfuerzo mental."
+      },
+      {
+        title: "Líneas de Tiempo Visuales",
+        body: "Mira tu día de un vistazo con horarios visuales, iconos y colores. Diseñado para mentes que piensan en imágenes, no en listas."
+      },
+      {
+        title: "Chequeos Emocionales",
+        body: "Un pulso gentil antes de tareas pesadas. Flowē nota cuando estás abrumado y sugiere descansos o alternativas más cortas."
+      },
+      {
+        title: "Recordatorios Amables",
+        body: "Sin alarmas estridentes ni notificaciones rojas. Empujoncitos suaves que se sienten como un amigo, no como una campana de escuela."
+      },
+      {
+        title: "Descomposicion de Tareas con IA",
+        body: "Escribe \"Escribir mi reporte\" y Flowē lo divide en pasos de 5 minutos. La abrumación desaparece. La acción comienza."
+      },
+      {
+        title: "Modo de Desconexión",
+        body: "Un ritual de cierre de día que ayuda a tu cerebro a salir del hiperfoco y realmente descansar. Higiene del sueño para neurodivergentes."
+      }
+    ]
+  },
+  compare: {
+    eyebrow: "La Ventaja Flowē",
+    title: "El estándar que otros<br />no están alcanzando",
+    body: "Creamos Flowē para ser el motor de rutinas más accesible e inteligente jamás hecho, sin importar tu plataforma o ubicación.",
+    header: ["Función", "Competencia", "Flowē"],
+    subtitles: ["Plataformas limitadas", "Acceso universal"],
+    rows: [
+      { name: "Soporte de Plataformas", tiimo: "Principalmente iOS", flowe: "Android + iOS + Web", check: true },
+      { name: "Suscripción", tiimo: "Estática y costosa", flowe: "Precios globales justos", check: true },
+      { name: "Rutinas con IA adaptativa", tiimo: "Estrictamente manual", flowe: "Aprende tus patrones", check: true },
+      { name: "Descomposición de tareas", tiimo: "No", flowe: "Sí", check: true },
+      { name: "Chequeos emocionales", tiimo: "No", flowe: "Sí", check: true },
+      { name: "Idiomas soportados", tiimo: "Principalmente inglés", flowe: "Nativo ES + EN", check: true },
+      { name: "Beta abierta", tiimo: "Lista de espera", flowe: "Acceso inmediato", check: true }
+    ]
+  },
+  testimonials: {
+    eyebrow: "De la comunidad",
+    title: "Lo que dicen nuestros<br />beta testers",
+    items: [
+      {
+        text: "Finalmente una app que no me hace sentir mal por no terminar mis tareas. La IA simplemente... se adapta. Sentí que me entendía desde el primer día.",
+        name: "Mariana R.",
+        label: "TDAH"
+      },
+      {
+        text: "He probado todas las apps de productividad. Flowē es la primera que no desinstalo tras una semana. La línea visual es justo como mi cerebro necesita ver el tiempo.",
+        name: "Diego A.",
+        label: "Autismo + TDAH"
+      },
+      {
+        text: "Otras herramientas eran muy caras o exclusivas. Flowē hace más, cuesta menos y el dev escucha en Discord. Esta es la indicada.",
+        name: "Sofía V.",
+        label: "Dislexia"
+      }
+    ]
+  },
+  updates: {
+    eyebrow: "Novedades de desarrollo",
+    title: "Construido en público",
+    body: "Sigue el viaje de la idea al producto. Compartimos todo: decisiones, aprendizajes y progreso honesto.",
+    posts: [
+      {
+        tag: "Anuncio",
+        title: "Flowē está oficialmente en desarrollo",
+        excerpt: "Presentamos Flowē — una app en Flutter para personas neurodivergentes que merecen mejores herramientas. Aquí te contamos el porqué.",
+        date: "Marzo 2026"
+      },
+      {
+        tag: "Previa de Funciones",
+        title: "Cómo funciona el motor de IA",
+        excerpt: "Un vistazo profundo a nuestro motor de rutinas basado en RAG: cómo Flowē aprende sin guardar datos sensibles.",
+        date: "Marzo 2026"
+      },
+      {
+        tag: "Diseño",
+        title: "Diseñando para mentes diversas: lo aprendido",
+        excerpt: "Nuestro proceso de UX, los principios que adoptamos y por qué la mayoría de apps fallan desde el primer registro.",
+        date: "Muy pronto"
+      }
+    ]
+  },
+  beta: {
+    title: "Sé parte de<br /><em>la primera ola.</em>",
+    body: "Únete al beta de Flowē y ayuda a darle forma a la app. Tendrás acceso anticipado, contacto directo con el equipo y serás el primero en probar todo.",
+    placeholder: "tu@correo.com",
+    button: "Unirse al Beta →",
+    success: "¡Ya estás en la lista! Nos pondremos en contacto pronto.",
+    error: "Ingresa un correo válido",
+    note: "Respetamos tu privacidad. Cero spam, siempre.",
+    perks: ["Gratis en beta", "Android & iOS", "Influye en el producto", "Comunidad de Discord"]
+  },
+  footer: {
+    tagline: "Tu ritmo, tu flow.<br />Una app de productividad para mentes neurodivergentes.",
+    cols: {
+      product: {
+        title: "Producto",
+        links: ["Funciones", "Por qué Flowē", "Unirse al Beta", "Mapa de ruta"]
+      },
+      updates: {
+        title: "Novedades",
+        links: ["Blog", "Cambios", "Notas dev", "Boletín"]
+      },
+      info: {
+        title: "Información",
+        links: ["Acerca de", "Privacidad", "Términos", "Contacto"]
+      }
+    },
+    copy: "© 2026 Flowē. Todos los derechos reservados.",
+    made: "Hecho con cariño 🌍"
+  }
+};
+
+export type Translations = typeof en;


### PR DESCRIPTION
## 🔗 Related Issue
Closes #N/A

---

## 🔖 Title
Performance optimizations, i18n support, and component refactor

---

## 📝 Description
The site was experiencing significant scroll jank caused by excessive GPU compositing work (multiple backdrop-filter blur operations over a live WebGL background) and a Navbar scroll listener that triggered layout reflow on every scroll event. This PR resolves all performance bottlenecks, fixes font loading, and adds full ES/EN internationalization.

---

## 🔄 Changes Made
- [x] Replace Navbar scroll listener with IntersectionObserver — eliminates per-scroll `getBoundingClientRect()` reflow
- [x] Remove `backdrop-filter` from `beta-cta`, `manifesto`, `hero-chip` — these were the heaviest GPU compositing operations over the animated shader
- [x] Remove `filter: blur(60px)` on `.feature-card::before` hover pseudo-element
- [x] Remove `will-change` from base `.reveal` CSS rule — was creating 30+ compositor layers simultaneously at page load
- [x] Reduce reveal animation duration 0.7s → 0.4s and translateY 30px → 16px to reduce stutter on fast scroll
- [x] Replace `width` keyframe animation on phone progress bar with `transform: scaleX()` to keep it GPU-only
- [x] Reduce ChromaFlow shader `dpr` from 1 to 0.75 to reduce second canvas pixel workload
- [x] Fix Next.js font variables — fonts were falling back to system because `font.variable` classNames were missing from `<body>`
- [x] Add full i18n support: `LanguageContext`, `translations/index.ts` (ES + EN), `LanguageSwitcher` component
- [x] Refactor all section components to consume translation context
- [x] Add `Icons.tsx` with proper SVG icons (X, Instagram, Discord, GitHub) for Footer social links

---

## 📸 Screenshots (if applicable)
N/A — changes are performance and logic, no visual regressions intended.

---

## 🗒️ Additional Notes
- ChromaFlow (mouse-reactive color effect) is intentionally kept — it is a core UX feature and must not be removed.
- `backdrop-filter` was removed only from full-width dark sections; glass cards (feature, testimonial, update) retain their `blur(4px)` for the glassmorphism aesthetic.