### PR TITLE
fix(a11y): remove zoom lock, fix form semantics, add keyboard nav and ARIA labels

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link
           rel="preconnect"

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -19,16 +19,16 @@ export default function Footer() {
               dangerouslySetInnerHTML={{ __html: t.footer.tagline }}
             />
             <div className="footer-social">
-              <a href="#" className="social-link" title="Twitter/X">
+              <a href="#" className="social-link" aria-label="Twitter/X">
                 <TwitterIcon />
               </a>
-              <a href="#" className="social-link" title="Instagram">
+              <a href="#" className="social-link" aria-label="Instagram">
                 <InstagramIcon />
               </a>
-              <a href="#" className="social-link" title="Discord">
+              <a href="#" className="social-link" aria-label="Discord">
                 <DiscordIcon />
               </a>
-              <a href="#" className="social-link" title="GitHub">
+              <a href="#" className="social-link" aria-label="GitHub">
                 <GithubIcon />
               </a>
             </div>

--- a/src/components/sections/BetaCTA.tsx
+++ b/src/components/sections/BetaCTA.tsx
@@ -9,14 +9,15 @@ export default function BetaCTA() {
   const [status, setStatus] = useState<"idle" | "loading" | "success" | "error" | "serverError">("idle");
   const { t } = useLanguage();
 
-  const handleSupportClick = async () => {
+  const handleSubmit = async (e: { preventDefault(): void }) => {
+    e.preventDefault();
     if (!email || !email.includes("@")) {
       setStatus("error");
       return;
     }
-    
+
     setStatus("loading");
-    
+
     try {
       const res = await fetch("/api/waitlist", {
         method: "POST",
@@ -38,7 +39,7 @@ export default function BetaCTA() {
   return (
     <section className="beta-cta" id="beta">
       <div className="beta-inner">
-        <h2 
+        <h2
           className="beta-title reveal"
           dangerouslySetInnerHTML={{ __html: t.beta.title }}
         />
@@ -47,58 +48,60 @@ export default function BetaCTA() {
         </p>
 
         {status !== "success" ? (
-          <div className="email-form reveal" id="betaForm">
+          <form className="email-form reveal" id="betaForm" onSubmit={handleSubmit}>
+            <label htmlFor="beta-email" className="sr-only">
+              {t.beta.placeholder}
+            </label>
             <input
+              id="beta-email"
               type="email"
               className="email-input"
               placeholder={t.beta.placeholder}
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") handleSupportClick();
-              }}
+              required
+              autoComplete="email"
               style={{
                 borderColor:
                   status === "error" ? "rgba(91,143,185,0.8)" : undefined,
               }}
             />
-            <button className="btn-rose" onClick={handleSupportClick} disabled={status === "loading"}>
+            <button className="btn-rose" type="submit" disabled={status === "loading"}>
               {status === "loading" ? "..." : t.beta.button}
             </button>
-          </div>
+          </form>
         ) : (
-            <div
-              className="form-success reveal visible"
-              style={{ display: "flex", animation: "fadeUp 0.5s ease both" }}
-            >
-              <DynamicIcon type="check" /> {t.beta.success}
-            </div>
-          )}
-  
-          {status === "error" && (
-            <p style={{ color: "rgba(91,143,185,0.8)", fontSize: "0.8rem", marginTop: "-0.5rem", marginBottom: "1rem" }}>
-              {t.beta.error}
-            </p>
-          )}
-
-          {status === "serverError" && (
-            <p style={{ color: "var(--warning)", fontSize: "0.85rem", marginTop: "-0.5rem", marginBottom: "1rem", fontWeight: 600 }}>
-              {/* Note: In a production app you might parse text from the API error JSON here */}
-              {t.beta.serverError || "Error interno del servidor. Por favor intenta de nuevo."}
-            </p>
-          )}
-  
-          <p className="beta-note reveal">
-            {t.beta.note}
-          </p>
-  
-          <div className="beta-perks reveal">
-            {t.beta.perks.map((perk, index) => (
-              <div key={index} className="beta-perk" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-                <DynamicIcon type="check" /> {perk}
-              </div>
-            ))}
+          <div
+            className="form-success reveal visible"
+            style={{ display: "flex", animation: "fadeUp 0.5s ease both" }}
+          >
+            <DynamicIcon type="check" /> {t.beta.success}
           </div>
+        )}
+
+        {status === "error" && (
+          <p style={{ color: "rgba(91,143,185,0.8)", fontSize: "0.8rem", marginTop: "-0.5rem", marginBottom: "1rem" }}>
+            {t.beta.error}
+          </p>
+        )}
+
+        {status === "serverError" && (
+          <p style={{ color: "var(--warning)", fontSize: "0.85rem", marginTop: "-0.5rem", marginBottom: "1rem", fontWeight: 600 }}>
+            {t.beta.serverError || "Error interno del servidor. Por favor intenta de nuevo."}
+          </p>
+        )}
+
+        <p className="beta-note reveal">
+          {t.beta.note}
+        </p>
+
+        <div className="beta-perks reveal">
+          {t.beta.perks.map((perk, index) => (
+            <div key={index} className="beta-perk" style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+              <DynamicIcon type="check" /> {perk}
+            </div>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/src/components/ui/LanguageSwitcher.tsx
+++ b/src/components/ui/LanguageSwitcher.tsx
@@ -12,13 +12,22 @@ export default function LanguageSwitcher({ darkNavbar = false, className = "" }:
   const { locale, setLocale } = useLanguage();
 
   return (
-    <div 
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label={locale === "en" ? "Switch to Spanish" : "Switch to English"}
       className={`relative flex items-center p-0.5 rounded-full border border-white/10 backdrop-blur-md transition-all duration-300 cursor-pointer w-[80px] h-[28px] overflow-hidden ${
-        darkNavbar 
-          ? "bg-black/10" 
+        darkNavbar
+          ? "bg-black/10"
           : "bg-white/20 shadow-sm"
       } ${className}`}
       onClick={() => setLocale(locale === "en" ? "es" : "en")}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          setLocale(locale === "en" ? "es" : "en");
+        }
+      }}
     >
       {/* Background Pill - The Glass Slide */}
       <motion.div


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4

---

## 🔖 Title
Fix accessibility regressions — viewport zoom lock, form semantics, keyboard navigation, ARIA labels

---

## 📝 Description
Four accessibility regressions were found across the landing page, all contradicting the brand's neurodivergent-friendly positioning. This PR fixes them together since they are small, independent, and share the same audit context.

---

## 🔄 Changes Made
- [ ] **`src/app/layout.tsx`** — Removed `maximum-scale=1, user-scalable=0` from the viewport meta tag. Restores pinch-to-zoom on mobile (WCAG 1.4.4 criterion).
- [ ] **`src/components/sections/BetaCTA.tsx`** — Replaced the `<div id="betaForm">` wrapper with a `<form onSubmit>`. Added a visually hidden `<label>` (Tailwind `sr-only`), `required`, and `autoComplete="email"` to the input. Button is now `type="submit"` — native Enter-key submission and browser autofill now work correctly.
- [ ] **`src/components/ui/LanguageSwitcher.tsx`** — Added `role="button"`, `tabIndex={0}`, `aria-label` (dynamic: "Switch to Spanish" / "Switch to English"), and `onKeyDown` handler for Enter and Space keys.
- [ ] **`src/components/layout/Footer.tsx`** — Replaced `title` attributes on social icon links with `aria-label` (Twitter/X, Instagram, Discord, GitHub). Screen readers now announce them correctly instead of relying on tooltip text.

---

## 📸 Screenshots (if applicable)
No visual changes — all fixes are semantic/structural.

---

## 🗒️ Additional Notes
- The viewport fix is the highest-priority item: `user-scalable=0` is especially contradictory for a product marketed to neurodivergent users who rely on zoom.
- `React.FormEvent` is deprecated in `@types/react@19`; the handler uses a minimal structural type `{ preventDefault(): void }` instead to avoid the deprecation warning.
- The two pre-existing lint warnings (`_err` unused in BetaCTA, stale eslint-disable in DynamicIcon) are out of scope and untouched.