### PR TITLE
feat(security): add HTTP security headers — CSP report-only, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,44 @@
 import type { NextConfig } from "next";
 
+const isDev = process.env.NODE_ENV === "development";
+
+const cspReportOnly = `
+  default-src 'self';
+  script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""};
+  style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+  font-src 'self' https://fonts.gstatic.com;
+  img-src 'self' blob: data:;
+  connect-src 'self';
+  object-src 'none';
+  base-uri 'self';
+  form-action 'self';
+  frame-ancestors 'none';
+  upgrade-insecure-requests;
+`
+  .replace(/\s{2,}/g, " ")
+  .trim();
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          { key: "X-Frame-Options", value: "SAMEORIGIN" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=()",
+          },
+          {
+            key: "Content-Security-Policy-Report-Only",
+            value: cspReportOnly,
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## 🔗 Related Issue
Closes #5

---

## 🔖 Title
Add HTTP security headers via next.config headers()

---

## 📝 Description
The site served only HSTS. This adds the remaining standard headers directly in `next.config.ts` via the `headers()` export — no component changes needed. CSP ships as report-only so violations can be observed in the browser console and DevTools without breaking the shader canvas, Google Fonts loading, or Next.js inline scripts.

---

## 🔄 Changes Made
- [x] **`next.config.ts`** — Added `headers()` export with source `/(.*)`
- [x] `X-Frame-Options: SAMEORIGIN` — prevents clickjacking
- [x] `X-Content-Type-Options: nosniff` — blocks MIME-type sniffing
- [x] `Referrer-Policy: strict-origin-when-cross-origin`
- [x] `Permissions-Policy: camera=(), microphone=(), geolocation=()` — disables unused browser APIs
- [x] `Content-Security-Policy-Report-Only` — audit-mode CSP covering all known sources (Google Fonts, Next.js inline scripts, same-origin connects and images)

---

## 📸 Screenshots (if applicable)
No visual changes. Headers are visible in browser DevTools → Network → Response Headers.

---

## 🗒️ Additional Notes
- **CSP is report-only on purpose.** The site uses `shaders/react` (bundled WebGL, no external script) and Google Fonts (external stylesheet + font files). The policy accounts for both. Once no violations are observed in production, promote to `Content-Security-Policy` by renaming the key.
- The policy includes `'unsafe-inline'` for scripts and styles because Next.js App Router emits inline hydration scripts. Promoting to enforcing will require either nonces (via a proxy file) or SRI — both documented in `node_modules/next/dist/docs/01-app/02-guides/content-security-policy.md`.
- `unsafe-eval` is allowed in dev only, as React uses `eval` for enhanced error stack reconstruction in development.
- `access-control-allow-origin: *` on the HTML root is set by Vercel infrastructure and is not overridden here.