### PR TITLE
feat(seo): add Open Graph, Twitter Cards, JSON-LD, canonical and hreflang

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,62 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { ShaderBackground } from "@/components/layout/ShaderBackground";
+import { LanguageProvider } from "@/context/LanguageContext";
 
-export const metadata: Metadata = {
-  title: "Flowē — Your rhythm, your flow.",
-  description: "A routines app designed for the way your brain actually works — with adaptive AI, visual schedules, and zero overwhelm.",
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name: "Flowē",
+  description:
+    "A routines app designed for the way your brain actually works — with adaptive AI, visual schedules, and zero overwhelm.",
+  url: "https://www.useflowe.com",
+  applicationCategory: "LifestyleApplication",
+  operatingSystem: "iOS, Android",
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "USD",
+    availability: "https://schema.org/PreOrder",
+  },
 };
 
-import { LanguageProvider } from "@/context/LanguageContext";
+export const metadata: Metadata = {
+  metadataBase: new URL("https://www.useflowe.com"),
+  title: "Flowē — Your rhythm, your flow.",
+  description:
+    "A routines app designed for the way your brain actually works — with adaptive AI, visual schedules, and zero overwhelm.",
+  alternates: {
+    canonical: "/",
+    languages: {
+      en: "/",
+      es: "/",
+      "x-default": "/",
+    },
+  },
+  openGraph: {
+    title: "Flowē — Your rhythm, your flow.",
+    description:
+      "A routines app designed for the way your brain actually works — with adaptive AI, visual schedules, and zero overwhelm.",
+    url: "https://www.useflowe.com",
+    siteName: "Flowē",
+    type: "website",
+    images: [
+      {
+        url: "/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "Flowē — Your rhythm, your flow.",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Flowē — Your rhythm, your flow.",
+    description:
+      "A routines app designed for the way your brain actually works — with adaptive AI, visual schedules, and zero overwhelm.",
+    images: ["/og-image.png"],
+  },
+};
 
 export default function RootLayout({
   children,
@@ -27,6 +76,10 @@ export default function RootLayout({
         <link
           href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400;1,700&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;1,9..40,300&family=DM+Mono:wght@300;400&family=Great+Vibes&display=swap"
           rel="stylesheet"
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
       </head>
       <body>


### PR DESCRIPTION
## 🔗 Related Issue
Closes #6

---

## 🔖 Title
Add social preview metadata, JSON-LD structured data, canonical link and hreflang alternates

---

## 📝 Description
Sharing the landing URL on any social platform produced no preview card. This is a direct conversion loss on every shared link during beta. All changes are purely metadata — zero visual impact on the page itself.

---

## 🔄 Changes Made
- [x] **`src/app/layout.tsx`** — Expanded `metadata` export with `metadataBase`, `openGraph`, `twitter`, and `alternates`
- [x] `openGraph`: title, description, url, siteName, type `website`, and image at `/og-image.png` (1200×630)
- [x] `twitter`: `summary_large_image` card with same title, description, and image
- [x] `alternates.canonical`: `"/"` (resolves to `https://www.useflowe.com` via `metadataBase`)
- [x] `alternates.languages`: `en`, `es`, and `x-default` — all pointing to `"/"` since locale is toggled client-side via localStorage, not via separate URL paths
- [x] JSON-LD `SoftwareApplication` schema injected via `<script type="application/ld+json">` in the layout `<head>`

---

## 📸 Screenshots (if applicable)
No visible UI changes. Preview can be validated with [opengraph.xyz](https://www.opengraph.xyz) once `/public/og-image.png` exists.

---

## 🗒️ Additional Notes
- **`/public/og-image.png` does not exist yet** — the OG and Twitter Card image will 404 until it's created. The image should be 1200×630px following brand colors (`#EDF1F5` background, `#5B8FB9` primary, `#2D3748` text). Alternatively, create `src/app/opengraph-image.tsx` using Next.js `ImageResponse` for programmatic generation at build time.
- The `lang="en"` on `<html>` is the correct server-side default. `LanguageContext` already calls `document.documentElement.lang = newLocale` on every locale switch, so the attribute updates dynamically on the client without requiring a cookie or SSR locale detection.
- `hreflang` for ES points to the same URL as EN because the site is single-URL with client-side locale. If dedicated `/es/*` routes are added later, update `alternates.languages.es` accordingly.