### PR TITLE
feat(legal): add explicit consent to waitlist form and persist evidence in API

### DIFF
--- a/src/app/api/waitlist/route.ts
+++ b/src/app/api/waitlist/route.ts
@@ -1,9 +1,11 @@
 import { NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/lib/supabase/server';
 
+const CONSENT_VERSION = '1.0';
+
 export async function POST(request: Request) {
   try {
-    const { email } = await request.json();
+    const { email, consent } = await request.json();
 
     if (!email || !email.includes('@')) {
       return NextResponse.json(
@@ -12,10 +14,21 @@ export async function POST(request: Request) {
       );
     }
 
-    // Insert the email into the 'waitlist' table
+    if (consent !== true) {
+      return NextResponse.json(
+        { error: 'Consent is required.' },
+        { status: 400 }
+      );
+    }
+
     const { data, error } = await supabaseAdmin
       .from('waitlist')
-      .insert([{ email }])
+      .insert([{
+        email,
+        consent: true,
+        consented_at: new Date().toISOString(),
+        consent_version: CONSENT_VERSION,
+      }])
       .select();
 
     if (error) {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -754,6 +754,12 @@ section {
 .email-input:focus { border-color: var(--primary-soft); background: rgba(255,255,255,0.15); }
 .btn-rose { background: var(--primary); color: white; border: none; padding: 0.85rem 1.75rem; border-radius: 100px; font-family: 'DM Sans', sans-serif; font-size: 0.95rem; font-weight: 600; cursor: pointer; transition: all 0.2s; white-space: nowrap; box-shadow: 0 8px 24px rgba(91,143,185,0.35); }
 .btn-rose:hover { background: #4A7EA8; transform: translateY(-2px); box-shadow: 0 12px 32px rgba(91,143,185,0.5); }
+.btn-rose:disabled { opacity: 0.45; cursor: not-allowed; transform: none; box-shadow: none; }
+.consent-row { width: 100%; display: flex; align-items: flex-start; gap: 0.6rem; text-align: left; margin-top: 0.25rem; }
+.consent-row input[type="checkbox"] { width: 1rem; height: 1rem; accent-color: var(--primary); flex-shrink: 0; margin-top: 0.15rem; cursor: pointer; }
+.consent-row label { font-size: 0.8rem; color: rgba(255,255,255,0.6); line-height: 1.45; cursor: pointer; }
+.consent-row label a { color: rgba(255,255,255,0.85); text-decoration: underline; }
+.age-note { font-size: 0.75rem; color: rgba(255,255,255,0.38); margin-top: 0.25rem; margin-bottom: 0.75rem; }
 .beta-note { font-size: 0.8rem; font-weight: 500; color: rgba(255,255,255,0.5); }
 .beta-perks { display: flex; gap: 1.5rem; justify-content: center; margin-top: 2.5rem; flex-wrap: wrap; }
 .beta-perk { display: flex; align-items: center; gap: 0.4rem; font-size: 0.85rem; font-weight: 500; color: rgba(255,255,255,0.7); }

--- a/src/components/sections/BetaCTA.tsx
+++ b/src/components/sections/BetaCTA.tsx
@@ -6,6 +6,7 @@ import DynamicIcon from "@/components/ui/DynamicIcon";
 
 export default function BetaCTA() {
   const [email, setEmail] = useState("");
+  const [consent, setConsent] = useState(false);
   const [status, setStatus] = useState<"idle" | "loading" | "success" | "error" | "serverError">("idle");
   const { t } = useLanguage();
 
@@ -22,7 +23,7 @@ export default function BetaCTA() {
       const res = await fetch("/api/waitlist", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email }),
+        body: JSON.stringify({ email, consent }),
       });
 
       if (!res.ok) {
@@ -66,9 +67,26 @@ export default function BetaCTA() {
                   status === "error" ? "rgba(91,143,185,0.8)" : undefined,
               }}
             />
-            <button className="btn-rose" type="submit" disabled={status === "loading"}>
+            <button
+              className="btn-rose"
+              type="submit"
+              disabled={status === "loading" || !consent}
+            >
               {status === "loading" ? "..." : t.beta.button}
             </button>
+            <div className="consent-row">
+              <input
+                id="beta-consent"
+                type="checkbox"
+                checked={consent}
+                onChange={(e) => setConsent(e.target.checked)}
+                required
+              />
+              <label
+                htmlFor="beta-consent"
+                dangerouslySetInnerHTML={{ __html: t.beta.consent }}
+              />
+            </div>
           </form>
         ) : (
           <div
@@ -90,6 +108,8 @@ export default function BetaCTA() {
             {t.beta.serverError || "Error interno del servidor. Por favor intenta de nuevo."}
           </p>
         )}
+
+        <p className="age-note reveal">{t.beta.ageNote}</p>
 
         <p className="beta-note reveal">
           {t.beta.note}

--- a/src/lib/translations/index.ts
+++ b/src/lib/translations/index.ts
@@ -136,6 +136,8 @@ export const en = {
     error: "Please enter a valid email",
     serverError: "Something went wrong. Please try again later.",
     note: "We respect your inbox. No spam, ever.",
+    consent: "I have read and agree to the <a href=\"/privacy\">Privacy Policy</a>. I consent to Flowē storing my email to send beta access and product updates.",
+    ageNote: "By joining you confirm you are 13 or older.",
     perks: ["Free during beta", "Android & iOS", "Shape the product", "Discord community"]
   },
   footer: {
@@ -297,6 +299,8 @@ export const es = {
     error: "Ingresa un correo válido",
     serverError: "Hubo un error al procesar tu solicitud. Inténtalo más tarde.",
     note: "Respetamos tu privacidad. Cero spam, siempre.",
+    consent: "He leído y acepto la <a href=\"/privacy\">Política de Privacidad</a>. Doy mi consentimiento para que Flowē almacene mi correo para enviarme acceso beta y actualizaciones del producto.",
+    ageNote: "Al unirte confirmas que tienes 13 años o más.",
     perks: ["Gratis en beta", "Android & iOS", "Influye en el producto", "Comunidad de Discord"]
   },
   footer: {


### PR DESCRIPTION
## 🔗 Related Issue
Closes #10

---

## 🔖 Title
Add GDPR/LGPD-compliant consent checkbox to beta waitlist form

---

## 📝 Description
The waitlist form was collecting emails with no legal consent mechanism. Under GDPR Art. 7 and LGPD Art. 8, consent must be freely given, specific, informed, and unambiguous. This PR adds an unchecked-by-default checkbox that blocks submission until checked, sends the consent flag to the API, and persists `consent`, `consented_at`, and `consent_version` to Supabase so any dispute can be resolved against the exact policy version the user accepted.

---

## 🔄 Changes Made
- [x] **`src/components/sections/BetaCTA.tsx`** — New `consent` state; submission blocked until checkbox checked; consent row added inside the `<form>` with a `<label>` containing a link to `/privacy`; age note added below the form
- [x] **`src/app/api/waitlist/route.ts`** — Validates `consent === true` (returns 400 otherwise); inserts `consent`, `consented_at`, and `consent_version: "1.0"` alongside the email
- [x] **`src/lib/translations/index.ts`** — Added `beta.consent` and `beta.ageNote` keys in EN and ES
- [x] **`src/app/globals.css`** — Added `.consent-row`, `.age-note`, and `.btn-rose:disabled` styles

---

## 📸 Screenshots (if applicable)
UI change: a checkbox row appears below the email/button row. Submit button is visually dimmed (opacity 0.45) until the checkbox is checked.

---

## 🗒️ Additional Notes
- `consent_version: "1.0"` is a constant in the API — increment it manually in sync with any Privacy Policy update to maintain an auditable consent trail.
- The Supabase table already has the required columns (`consent`, `consented_at`, `consent_version`) from the DB migration run before this PR.
- Pre-checked checkboxes are invalid under both GDPR and LGPD — the checkbox starts unchecked and has no default value.