### PR TITLE
feat(legal): add Privacy Policy and Terms of Service pages, wire footer links, add compare disclaimer

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -934,5 +934,19 @@ section {
 
 html { scroll-behavior: smooth; }
 
+/* ── LEGAL PAGES ── */
+.legal-page { max-width: 720px; margin: 0 auto; padding: 8rem 2rem 6rem; }
+.legal-page h1 { font-family: 'Playfair Display', serif; font-size: 2.5rem; font-weight: 700; color: var(--ink); margin-bottom: 0.4rem; line-height: 1.15; }
+.legal-meta { font-size: 0.82rem; color: var(--ink-muted); margin-bottom: 2.5rem; }
+.legal-page h2 { font-family: 'Playfair Display', serif; font-size: 1.25rem; font-weight: 700; color: var(--ink); margin-top: 2.5rem; margin-bottom: 0.6rem; }
+.legal-page p { font-size: 0.975rem; color: var(--ink-soft); line-height: 1.8; margin-bottom: 1rem; }
+.legal-page ul { padding-left: 1.4rem; margin-bottom: 1rem; }
+.legal-page li { font-size: 0.975rem; color: var(--ink-soft); line-height: 1.8; margin-bottom: 0.2rem; }
+.legal-page a { color: var(--primary); text-decoration: underline; }
+.legal-lang-toggle { display: flex; gap: 0.5rem; margin-bottom: 2.5rem; }
+.legal-lang-btn { background: none; border: 1px solid var(--border); color: var(--ink-muted); padding: 0.3rem 1rem; border-radius: 100px; font-size: 0.82rem; font-family: 'DM Sans', sans-serif; cursor: pointer; transition: all 0.2s; }
+.legal-lang-btn.active { background: var(--primary); border-color: var(--primary); color: white; }
+.compare-disclaimer { font-size: 0.78rem; color: var(--ink-muted); text-align: center; margin-top: 1.5rem; font-style: italic; }
+
 /* ── SUCCESS STATE ── */
 .form-success { display: none; align-items: center; justify-content: center; gap: 0.5rem; color: var(--secondary); font-size: 0.9rem; font-weight: 600; padding: 0.85rem 1.75rem; background: rgba(123,174,127,0.15); border-radius: 100px; border: 1px solid rgba(123,174,127,0.3); margin: 0 auto; }

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useState } from "react";
+import Navbar from "@/components/layout/Navbar";
+import Footer from "@/components/layout/Footer";
+
+export default function PrivacyPolicy() {
+  const [lang, setLang] = useState<"en" | "es">("en");
+
+  return (
+    <>
+      <Navbar />
+      <div className="legal-page">
+        <div className="legal-lang-toggle">
+          <button
+            className={`legal-lang-btn${lang === "en" ? " active" : ""}`}
+            onClick={() => setLang("en")}
+          >
+            EN
+          </button>
+          <button
+            className={`legal-lang-btn${lang === "es" ? " active" : ""}`}
+            onClick={() => setLang("es")}
+          >
+            ES
+          </button>
+        </div>
+
+        {lang === "en" ? <PrivacyEN /> : <PrivacyES />}
+      </div>
+      <Footer />
+    </>
+  );
+}
+
+function PrivacyEN() {
+  return (
+    <>
+      <h1>Privacy Policy</h1>
+      <p className="legal-meta">Version 1.0 — May 2026</p>
+
+      <h2>1. Who we are</h2>
+      <p>
+        Flowē (&quot;we&quot;, &quot;us&quot;, &quot;our&quot;) operates the website{" "}
+        <a href="https://www.useflowe.com">www.useflowe.com</a>. We are the data
+        controller responsible for your personal information. Contact us at{" "}
+        <a href="mailto:privacy@useflowe.com">privacy@useflowe.com</a>.
+      </p>
+
+      <h2>2. What we collect</h2>
+      <p>
+        When you join the waitlist, we collect your <strong>email address</strong> and
+        a record of your consent (timestamp and policy version). We collect nothing
+        else — no name, no device data, no cookies beyond what is strictly necessary
+        for the site to function.
+      </p>
+
+      <h2>3. Why we collect it</h2>
+      <p>
+        We use your email solely to notify you about beta access, product updates, and
+        Flowē launch news. We will never use it for unrelated marketing or share it
+        with third parties for their own marketing purposes.
+      </p>
+
+      <h2>4. Legal basis</h2>
+      <p>
+        We process your email on the basis of your freely given, informed consent
+        (GDPR Art. 6(1)(a) / LGPD Art. 7(I)). You may withdraw this consent at any
+        time by emailing{" "}
+        <a href="mailto:privacy@useflowe.com">privacy@useflowe.com</a> and we will
+        delete your data within 30 days.
+      </p>
+
+      <h2>5. How long we keep your data</h2>
+      <p>
+        We retain your email until you request removal, or until 12 months after the
+        public launch of Flowē — whichever comes first.
+      </p>
+
+      <h2>6. Data processor</h2>
+      <p>
+        Your email is stored securely on{" "}
+        <a href="https://supabase.com" target="_blank" rel="noopener noreferrer">
+          Supabase
+        </a>
+        , our database provider. Supabase acts as a data processor under our
+        instructions and is bound by a{" "}
+        <a
+          href="https://supabase.com/legal/dpa"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Data Processing Agreement
+        </a>
+        . No other third parties have access to your data.
+      </p>
+
+      <h2>7. Your rights</h2>
+      <p>
+        Under GDPR and LGPD you have the right to:
+      </p>
+      <ul>
+        <li><strong>Access</strong> — request a copy of the data we hold about you</li>
+        <li><strong>Rectification</strong> — ask us to correct inaccurate data</li>
+        <li><strong>Erasure</strong> — ask us to delete your data (&quot;right to be forgotten&quot;)</li>
+        <li><strong>Portability</strong> — receive your data in a machine-readable format</li>
+        <li><strong>Withdraw consent</strong> — opt out at any time without penalty</li>
+      </ul>
+      <p>
+        To exercise any of these rights, email{" "}
+        <a href="mailto:privacy@useflowe.com">privacy@useflowe.com</a>. We will
+        respond within 30 days.
+      </p>
+
+      <h2>8. Data security</h2>
+      <p>
+        Data is stored in an encrypted Supabase database with access restricted to
+        authorised team members only. We use HTTPS on all connections.
+      </p>
+
+      <h2>9. Changes to this policy</h2>
+      <p>
+        If we make material changes, we will update the version number and date at the
+        top of this page. Continued use of the waitlist after changes constitutes
+        acceptance of the updated policy.
+      </p>
+
+      <h2>10. Contact</h2>
+      <p>
+        Questions about this policy?{" "}
+        <a href="mailto:privacy@useflowe.com">privacy@useflowe.com</a>
+      </p>
+    </>
+  );
+}
+
+function PrivacyES() {
+  return (
+    <>
+      <h1>Política de Privacidad</h1>
+      <p className="legal-meta">Versión 1.0 — Mayo 2026</p>
+
+      <h2>1. Quiénes somos</h2>
+      <p>
+        Flowē (&quot;nosotros&quot;) opera el sitio web{" "}
+        <a href="https://www.useflowe.com">www.useflowe.com</a>. Somos el responsable
+        del tratamiento de tus datos personales. Puedes contactarnos en{" "}
+        <a href="mailto:privacy@useflowe.com">privacy@useflowe.com</a>.
+      </p>
+
+      <h2>2. Qué recopilamos</h2>
+      <p>
+        Al unirte a la lista de espera, recopilamos tu <strong>dirección de correo
+        electrónico</strong> y un registro de tu consentimiento (fecha y versión de la
+        política). No recopilamos nada más — sin nombre, sin datos del dispositivo, sin
+        cookies más allá de las estrictamente necesarias para el funcionamiento del
+        sitio.
+      </p>
+
+      <h2>3. Para qué lo usamos</h2>
+      <p>
+        Usamos tu correo únicamente para notificarte sobre el acceso beta, actualizaciones
+        del producto y el lanzamiento de Flowē. Nunca lo usaremos para marketing no
+        relacionado ni lo compartiremos con terceros para sus propios fines de marketing.
+      </p>
+
+      <h2>4. Base legal</h2>
+      <p>
+        Tratamos tu correo con base en tu consentimiento libre, informado y expreso
+        (LGPD Art. 7(I) / GDPR Art. 6(1)(a)). Puedes retirar este consentimiento en
+        cualquier momento escribiendo a{" "}
+        <a href="mailto:privacy@useflowe.com">privacy@useflowe.com</a> y eliminaremos
+        tus datos en un plazo de 30 días.
+      </p>
+
+      <h2>5. Por cuánto tiempo guardamos tus datos</h2>
+      <p>
+        Conservamos tu correo hasta que solicites su eliminación, o hasta 12 meses
+        después del lanzamiento público de Flowē — lo que ocurra primero.
+      </p>
+
+      <h2>6. Procesador de datos</h2>
+      <p>
+        Tu correo se almacena de forma segura en{" "}
+        <a href="https://supabase.com" target="_blank" rel="noopener noreferrer">
+          Supabase
+        </a>
+        , nuestro proveedor de base de datos. Supabase actúa como encargado del
+        tratamiento bajo nuestras instrucciones y está vinculado por un{" "}
+        <a
+          href="https://supabase.com/legal/dpa"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Acuerdo de Tratamiento de Datos
+        </a>
+        . Ningún otro tercero tiene acceso a tus datos.
+      </p>
+
+      <h2>7. Tus derechos</h2>
+      <p>Bajo la LGPD y el GDPR tienes derecho a:</p>
+      <ul>
+        <li><strong>Acceso</strong> — solicitar una copia de los datos que tenemos sobre ti</li>
+        <li><strong>Rectificación</strong> — pedirnos que corrijamos datos inexactos</li>
+        <li><strong>Supresión</strong> — pedirnos que eliminemos tus datos</li>
+        <li><strong>Portabilidad</strong> — recibir tus datos en un formato legible por máquina</li>
+        <li><strong>Retirar el consentimiento</strong> — en cualquier momento y sin penalización</li>
+      </ul>
+      <p>
+        Para ejercer cualquiera de estos derechos, escríbenos a{" "}
+        <a href="mailto:privacy@useflowe.com">privacy@useflowe.com</a>. Responderemos
+        en un plazo de 30 días.
+      </p>
+
+      <h2>8. Seguridad de los datos</h2>
+      <p>
+        Los datos se almacenan en una base de datos Supabase cifrada, con acceso
+        restringido únicamente a los miembros autorizados del equipo. Usamos HTTPS en
+        todas las conexiones.
+      </p>
+
+      <h2>9. Cambios en esta política</h2>
+      <p>
+        Si realizamos cambios importantes, actualizaremos el número de versión y la
+        fecha en la parte superior de esta página. El uso continuado de la lista de
+        espera tras los cambios implica la aceptación de la política actualizada.
+      </p>
+
+      <h2>10. Contacto</h2>
+      <p>
+        ¿Preguntas sobre esta política?{" "}
+        <a href="mailto:privacy@useflowe.com">privacy@useflowe.com</a>
+      </p>
+    </>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useState } from "react";
+import Navbar from "@/components/layout/Navbar";
+import Footer from "@/components/layout/Footer";
+
+export default function TermsOfService() {
+  const [lang, setLang] = useState<"en" | "es">("en");
+
+  return (
+    <>
+      <Navbar />
+      <div className="legal-page">
+        <div className="legal-lang-toggle">
+          <button
+            className={`legal-lang-btn${lang === "en" ? " active" : ""}`}
+            onClick={() => setLang("en")}
+          >
+            EN
+          </button>
+          <button
+            className={`legal-lang-btn${lang === "es" ? " active" : ""}`}
+            onClick={() => setLang("es")}
+          >
+            ES
+          </button>
+        </div>
+
+        {lang === "en" ? <TermsEN /> : <TermsES />}
+      </div>
+      <Footer />
+    </>
+  );
+}
+
+function TermsEN() {
+  return (
+    <>
+      <h1>Terms of Service</h1>
+      <p className="legal-meta">Version 1.0 — May 2026</p>
+
+      <h2>1. Nature of the service</h2>
+      <p>
+        Flowē is a pre-launch product currently in development. By joining the waitlist
+        you are expressing interest in a future product — you are not purchasing,
+        subscribing to, or receiving any software or service at this time. We make no
+        guarantees about the final product, its features, pricing, or launch date.
+      </p>
+
+      <h2>2. Eligibility</h2>
+      <p>
+        You confirm that you are at least 13 years old. If you are under 16 and located
+        in the European Union, you confirm that you have obtained the required parental
+        or guardian consent.
+      </p>
+
+      <h2>3. Acceptable use</h2>
+      <p>By joining the waitlist you agree not to:</p>
+      <ul>
+        <li>Provide false or misleading information</li>
+        <li>Use automated tools to submit multiple entries</li>
+        <li>Attempt to access systems or data beyond your authorisation</li>
+      </ul>
+
+      <h2>4. Communications</h2>
+      <p>
+        By joining the waitlist and providing consent, you agree to receive email
+        updates about Flowē. You may unsubscribe at any time by contacting us at{" "}
+        <a href="mailto:privacy@useflowe.com">privacy@useflowe.com</a> or by
+        clicking the unsubscribe link in any email we send.
+      </p>
+
+      <h2>5. Intellectual property</h2>
+      <p>
+        All content on this website — including text, graphics, logos, and code — is
+        the property of Flowē and protected by applicable intellectual property laws.
+        You may not reproduce or distribute it without prior written permission.
+      </p>
+
+      <h2>6. Limitation of liability</h2>
+      <p>
+        This website is provided &quot;as is&quot; without warranty of any kind. To the
+        fullest extent permitted by applicable law, Flowē is not liable for any indirect,
+        incidental, or consequential damages arising from your use of this site or the
+        waitlist service.
+      </p>
+
+      <h2>7. Governing law</h2>
+      <p>
+        These terms are governed by the laws of Brazil, where our infrastructure is
+        hosted. Any disputes will be subject to the exclusive jurisdiction of the courts
+        of Brazil. Nothing in these terms limits your rights under applicable consumer
+        protection or data protection laws in your country of residence.
+      </p>
+
+      <h2>8. Changes to these terms</h2>
+      <p>
+        We may update these terms from time to time. We will update the version number
+        and date above when we do. Continued use of the waitlist after changes means
+        you accept the updated terms.
+      </p>
+
+      <h2>9. Contact</h2>
+      <p>
+        Questions?{" "}
+        <a href="mailto:privacy@useflowe.com">privacy@useflowe.com</a>
+      </p>
+    </>
+  );
+}
+
+function TermsES() {
+  return (
+    <>
+      <h1>Términos de Servicio</h1>
+      <p className="legal-meta">Versión 1.0 — Mayo 2026</p>
+
+      <h2>1. Naturaleza del servicio</h2>
+      <p>
+        Flowē es un producto en fase de desarrollo previo al lanzamiento. Al unirte a
+        la lista de espera expresas interés en un producto futuro — no estás comprando,
+        suscribiéndote ni recibiendo ningún software o servicio en este momento. No
+        ofrecemos garantías sobre el producto final, sus funciones, precios ni fecha
+        de lanzamiento.
+      </p>
+
+      <h2>2. Elegibilidad</h2>
+      <p>
+        Confirmas que tienes al menos 13 años. Si tienes menos de 16 años y te
+        encuentras en la Unión Europea, confirmas que has obtenido el consentimiento
+        de tu padre, madre o tutor legal.
+      </p>
+
+      <h2>3. Uso aceptable</h2>
+      <p>Al unirte a la lista de espera aceptas no:</p>
+      <ul>
+        <li>Proporcionar información falsa o engañosa</li>
+        <li>Usar herramientas automatizadas para enviar múltiples registros</li>
+        <li>Intentar acceder a sistemas o datos más allá de tu autorización</li>
+      </ul>
+
+      <h2>4. Comunicaciones</h2>
+      <p>
+        Al unirte a la lista de espera y dar tu consentimiento, aceptas recibir
+        actualizaciones por correo sobre Flowē. Puedes cancelar la suscripción en
+        cualquier momento escribiendo a{" "}
+        <a href="mailto:privacy@useflowe.com">privacy@useflowe.com</a> o haciendo
+        clic en el enlace de baja en cualquier correo que te enviemos.
+      </p>
+
+      <h2>5. Propiedad intelectual</h2>
+      <p>
+        Todo el contenido de este sitio web — incluyendo textos, gráficos, logos y
+        código — es propiedad de Flowē y está protegido por las leyes de propiedad
+        intelectual aplicables. No puedes reproducirlo ni distribuirlo sin permiso
+        previo por escrito.
+      </p>
+
+      <h2>6. Limitación de responsabilidad</h2>
+      <p>
+        Este sitio web se proporciona &quot;tal cual&quot; sin garantía de ningún tipo.
+        En la medida máxima permitida por la ley aplicable, Flowē no es responsable
+        de daños indirectos, incidentales o consecuentes derivados del uso de este
+        sitio o del servicio de lista de espera.
+      </p>
+
+      <h2>7. Legislación aplicable</h2>
+      <p>
+        Estos términos se rigen por las leyes de Brasil, donde se aloja nuestra
+        infraestructura. Cualquier disputa estará sujeta a la jurisdicción exclusiva
+        de los tribunales de Brasil. Nada en estos términos limita tus derechos bajo
+        las leyes de protección al consumidor o protección de datos aplicables en tu
+        país de residencia.
+      </p>
+
+      <h2>8. Cambios en estos términos</h2>
+      <p>
+        Podemos actualizar estos términos de vez en cuando. Actualizaremos el número
+        de versión y la fecha indicada arriba cuando lo hagamos. El uso continuado de
+        la lista de espera tras los cambios implica la aceptación de los términos
+        actualizados.
+      </p>
+
+      <h2>9. Contacto</h2>
+      <p>
+        ¿Preguntas?{" "}
+        <a href="mailto:privacy@useflowe.com">privacy@useflowe.com</a>
+      </p>
+    </>
+  );
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -59,8 +59,8 @@ export default function Footer() {
               <div className="footer-col-title">{t.footer.cols.info.title}</div>
               <ul className="footer-links">
                 <li><a href="#">{t.footer.cols.info.links[0]}</a></li>
-                <li><a href="#">{t.footer.cols.info.links[1]}</a></li>
-                <li><a href="#">{t.footer.cols.info.links[2]}</a></li>
+                <li><a href="/privacy">{t.footer.cols.info.links[1]}</a></li>
+                <li><a href="/terms">{t.footer.cols.info.links[2]}</a></li>
                 <li><a href="#">{t.footer.cols.info.links[3]}</a></li>
               </ul>
             </div>

--- a/src/components/sections/Compare.tsx
+++ b/src/components/sections/Compare.tsx
@@ -45,6 +45,7 @@ export default function Compare() {
             </div>
           ))}
         </div>
+        <p className="compare-disclaimer">{t.compare.disclaimer}</p>
       </div>
     </section>
   );

--- a/src/lib/translations/index.ts
+++ b/src/lib/translations/index.ts
@@ -70,6 +70,7 @@ export const en = {
     body: "We built Flowē to be the most accessible and intelligent routine engine ever made, regardless of your platform or location.",
     header: ["Feature", "Competitors", "Flowē"],
     subtitles: ["Limited platforms", "Universal access"],
+    disclaimer: "Competitor information is based on publicly available data and is approximate. Features and pricing may have changed.",
     rows: [
       { name: "Platform Support", tiimo: "iOS mostly", flowe: "Android + iOS + Web", check: true },
       { name: "Subscription", tiimo: "Static high-tier", flowe: "Fair global pricing", check: true },
@@ -231,6 +232,7 @@ export const es = {
     body: "Creamos Flowē para ser el motor de rutinas más accesible e inteligente jamás hecho, sin importar tu plataforma o ubicación.",
     header: ["Función", "Competencia", "Flowē"],
     subtitles: ["Plataformas limitadas", "Acceso universal"],
+    disclaimer: "La información sobre competidores se basa en datos públicos y es aproximada. Las funciones y precios pueden haber cambiado.",
     rows: [
       { name: "Soporte de Plataformas", tiimo: "Principalmente iOS", flowe: "Android + iOS + Web", check: true },
       { name: "Suscripción", tiimo: "Estática y costosa", flowe: "Precios globales justos", check: true },


### PR DESCRIPTION
## 🔗 Related Issue
Closes #11

---

## 🔖 Title
Create /privacy and /terms pages, wire footer links, add competitor data disclaimer

---

## 📝 Description
Collecting emails without a visible, accessible Privacy Policy is a legal risk under GDPR Art. 13, LGPD Art. 9, and CCPA. All footer links for Privacy Policy and Terms pointed to `href="#"`. This PR creates both pages with bilingual EN/ES content and wires all the relevant footer links.

---

## 🔄 Changes Made
- [x] **`src/app/privacy/page.tsx`** — New page covering: data controller identity, data collected (email), purpose, legal basis (GDPR Art. 6(1)(a) / LGPD Art. 7(I)), Supabase as sub-processor (with DPA link), retention period (deletion request or 12 months post-launch), user rights (access, rectification, erasure, portability, withdrawal), contact email, version v1.0 May 2026. Bilingual EN/ES toggle.
- [x] **`src/app/terms/page.tsx`** — New page covering: pre-launch nature of service, minimum age (13+), acceptable use, communications opt-out path, IP ownership, limitation of liability, governing law (Brazil / LGPD jurisdiction), contact. Bilingual EN/ES toggle.
- [x] **`src/components/layout/Footer.tsx`** — Privacy Policy link → `/privacy`, Terms link → `/terms`. About and Contact remain `href="#"` until those pages exist.
- [x] **`src/components/sections/Compare.tsx`** — Renders `t.compare.disclaimer` below the comparison table
- [x] **`src/lib/translations/index.ts`** — Added `compare.disclaimer` in EN and ES
- [x] **`src/app/globals.css`** — Added `.legal-page`, `.legal-meta`, `.legal-lang-toggle`, `.legal-lang-btn`, `.compare-disclaimer` styles

---

## 📸 Screenshots (if applicable)
Two new routes accessible at `/privacy` and `/terms`. Both have an EN/ES toggle in the top-left.

---

## 🗒️ Additional Notes
- Contact email is `privacy@useflowe.com` — update this if the actual address differs before merging to production.
- `consent_version: "1.0"` in the API (issue #10 PR) corresponds to this version of the Privacy Policy. Both should be incremented together when the policy changes.
- The legal pages do NOT use a cookie banner — `localStorage` for locale preference is strictly functional and exempt from ePrivacy consent requirements.